### PR TITLE
feat: expand solo-dev harness with stack, commit, and guardrail additions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,6 +12,5 @@
   "license": "MIT",
   "keywords": ["spec-driven", "tdd", "harness", "workflow", "nodejs", "typescript"],
   "dependencies": ["superpowers"],
-  "hooks": "./hooks/hooks.json",
-  "mcpServers": "./mcp/github.json"
+  "hooks": "./hooks/hooks.json"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,12 @@ own manifest, and they all point at the one shared `skills/` dir.
 .cursor-plugin/plugin.json       Cursor manifest — skills only
 .agents/plugins/marketplace.json open-agents ("agents") marketplace entry
 skills/                          portable markdown skills (SKILL.md + assets) — shared by ALL agents
+commands/                        slash commands (*.md) — Claude only
 agents/                          Claude Code subagents (*.md) — Claude only
 hooks/                           hooks.json + zero-dep Node ESM scripts — Claude only
-mcp/github.json                  remote GitHub MCP — Claude
 ```
+
+GitHub access is via the `gh` CLI (no bundled MCP).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -19,23 +19,33 @@ Superpowers is declared as a dependency and installed automatically from the sam
 
 ## What it adds
 
-- **`plus-ultra:spec-conventions` skill** — `specs/NNN-slug.md` numbering + a spec template
-  (Problem, Goals/Non-goals, Acceptance criteria, Interface contracts, Data model, Test plan, Risks)
-  with a `status:` lifecycle (draft → approved → in-progress → done). Plus `docs/` layout for
-  architecture notes, ADRs, and the changelog.
+- **Skills (portable, `plus-ultra:*`):**
+  - *spec-conventions* — `specs/NNN-slug.md` numbering + a spec template (Problem, Goals/Non-goals,
+    Acceptance criteria, Interface contracts, Data model, Test plan, Risks) with a `status:` lifecycle
+    (draft → approved → in-progress → done). Plus `docs/` layout and an ADR template.
+  - *tech-stack* — the default stack: a TypeScript-everywhere **pnpm-workspaces monorepo** —
+    React + Vite (web), Hono (api), shared zod/types, Drizzle + Neon, vitest, Biome. Defaults, with
+    a stated escape hatch per row.
+  - *conventional-commits* — the commit message format (enforced by the commit-msg-lint hook).
+  - *new-project* — scaffolds the tech-stack monorepo + CI.
+- **Slash command:** `/plus-ultra:spec` — list specs, create the next-numbered spec, or flip a
+  spec's status.
 - **Guardrail hooks:**
-  - *commit-gate* (PreToolUse / `git commit`) — blocks a commit unless a test run passed this
-    session. Order is flexible: tests any time in the session, not necessarily before writing code.
   - *dangerous-command* (PreToolUse / Bash) — blocks `rm -rf` and force-pushes to `main`/`master`.
-  - *test-marker* (PostToolUse / Bash) — records a per-session marker when a test command exits 0.
-  - *auto-format* (PostToolUse / Write|Edit) — runs `eslint --fix` + `prettier --write` on edited
-    files under `src/**` (no-ops if tooling is absent).
+  - *secret-scan* (PreToolUse / `git commit`) — blocks a commit whose staged diff contains a
+    private key, cloud/API token, or a staged `.env` file.
+  - *commit-msg-lint* (PreToolUse / `git commit -m`) — blocks a header that isn't a Conventional Commit.
+  - *commit-gate* (PreToolUse / `git commit`) — blocks unless a test run passed this session (and, in
+    a TypeScript project, a typecheck). Order is flexible: checks any time in the session.
+  - *test-marker* (PostToolUse / Bash) — records a per-session marker when a test or typecheck exits 0.
+  - *auto-format* (PostToolUse / Write|Edit) — runs `biome check --write` on edited JS/TS/JSON files
+    anywhere in the repo (no-ops if Biome is absent).
   - *session-start* — reports which spec is `in-progress` (and what's approved/draft) so sessions
     resume without re-explaining context.
 - **Subagents:** `repo-explorer` (read-only scan), `code-reviewer` (diff vs the spec's acceptance
   criteria), `dep-auditor` (vet new npm packages).
-- **MCP:** remote GitHub MCP server (`https://api.githubcopilot.com/mcp/`). Authorize it once via
-  `/mcp` (OAuth) in an interactive session.
+- **GitHub:** no bundled MCP — use the `gh` CLI (with the `gh-cli` skill) from the shell for PRs,
+  issues, Actions, and releases.
 
 ## Naming
 
@@ -49,10 +59,10 @@ Structured skills-first, like Superpowers: the repo root is the plugin for every
 agent's manifest points at the one shared `skills/` dir. The `spec-conventions` skill (and its
 template) therefore works on Claude Code, Codex, Cursor, and any agent that reads `skills/`.
 
-Guardrail hooks and review subagents are **Claude Code only** — they rely on Claude's hook system
-(`PreToolUse`/`PostToolUse`/`SessionStart`) and subagent format, which other agents don't share. The
-Codex/Cursor manifests ship skills only (`hooks: {}`). To add another agent, drop in its
-`.<agent>-plugin/plugin.json` with `"skills": "./skills/"`.
+Guardrail hooks, the slash command, and review subagents are **Claude Code only** — they rely on
+Claude's hook system (`PreToolUse`/`PostToolUse`/`SessionStart`), command, and subagent formats,
+which other agents don't share. The Codex/Cursor manifests ship skills only (`hooks: {}`). To add
+another agent, drop in its `.<agent>-plugin/plugin.json` with `"skills": "./skills/"`.
 
 ## Hook scripts
 
@@ -68,8 +78,9 @@ Hooks are dependency-free Node ESM scripts under `hooks/`. They read the hook JS
 .codex-plugin/plugin.json        Codex manifest (skills only)
 .cursor-plugin/plugin.json       Cursor manifest (skills only)
 .agents/plugins/marketplace.json open-agents marketplace entry
-skills/spec-conventions/         SKILL.md + template.md — shared by all agents
+skills/                          portable skills (spec-conventions, tech-stack,
+                                 conventional-commits, new-project) — shared by all agents
+commands/spec.md                 /plus-ultra:spec lifecycle command — Claude only
 agents/                          repo-explorer, code-reviewer, dep-auditor — Claude only
 hooks/                           hooks.json + *.mjs — Claude only
-mcp/github.json                  remote GitHub MCP — Claude
 ```

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -1,0 +1,31 @@
+---
+description: Manage spec-driven lifecycle — list specs, create the next-numbered spec, or flip a spec's status. Follows plus-ultra:spec-conventions.
+argument-hint: "[new <slug> | status <NNN|slug> <draft|approved|in-progress|done> | list]"
+---
+
+Manage the repo's specs under `specs/`, following the `plus-ultra:spec-conventions` skill. Read that
+skill if you need the numbering/lifecycle rules.
+
+Arguments: `$ARGUMENTS`
+
+Interpret the arguments and act:
+
+## `list` (or no arguments)
+Scan `specs/*.md`, read each file's `status:` frontmatter, and print a grouped summary:
+In progress → Approved → Drafts → Done. Note if more than one spec is `in-progress` (normally only
+one should be).
+
+## `new <slug>`
+1. Find the highest existing `NNN` in `specs/` and add one (zero-padded 3 digits). Never reuse.
+2. Copy the template from the `plus-ultra:spec-conventions` skill (`template.md`) into
+   `specs/NNN-<slug>.md` with `status: draft`.
+3. Fill in the title; leave the sections as prompts for the user to complete. Report the path.
+
+## `status <NNN|slug> <new-status>`
+1. Resolve the spec file by number or slug.
+2. Validate the transition follows `draft → approved → in-progress → done` (warn, don't hard-block,
+   on a skip or reversal — the user may have a reason).
+3. If moving a spec to `in-progress` while another is already `in-progress`, call it out and confirm.
+4. Edit only the `status:` field in the frontmatter. Report the change.
+
+If the arguments don't match any of these, explain the three forms and stop.

--- a/hooks/_lib.mjs
+++ b/hooks/_lib.mjs
@@ -1,4 +1,5 @@
 // Shared helpers for plus-ultra hooks. Zero dependencies.
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 
 // Read and parse the hook JSON payload from stdin. Returns {} on empty/invalid.
 export async function readInput() {
@@ -44,4 +45,45 @@ export function allow() {
 export function stateDir() {
   const root = process.env.CLAUDE_PROJECT_DIR || process.cwd();
   return `${root}/.claude/plus-ultra/state`;
+}
+
+// Per-session marker file (records testPassedAt / typecheckPassedAt).
+export function markerPath(sessionId) {
+  return `${stateDir()}/${String(sessionId || "default")}.json`;
+}
+
+// Read the session marker as an object, or {} if absent/invalid.
+export function readMarker(sessionId) {
+  try {
+    return JSON.parse(readFileSync(markerPath(sessionId), "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+// Merge fields into the session marker. Never throws.
+export function mergeMarker(sessionId, patch) {
+  try {
+    mkdirSync(stateDir(), { recursive: true });
+    writeFileSync(markerPath(sessionId), JSON.stringify({ ...readMarker(sessionId), ...patch }, null, 2));
+  } catch {
+    // never disrupt the session over a marker write failure
+  }
+}
+
+// Does this project use TypeScript? True if a tsconfig.json exists at the root
+// or in any immediate apps/* or packages/* workspace (monorepo layout).
+export function isTsProject(root) {
+  const base = root || process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  if (existsSync(`${base}/tsconfig.json`)) return true;
+  for (const dir of ["apps", "packages"]) {
+    try {
+      for (const entry of readdirSync(`${base}/${dir}`, { withFileTypes: true })) {
+        if (entry.isDirectory() && existsSync(`${base}/${dir}/${entry.name}/tsconfig.json`)) return true;
+      }
+    } catch {
+      // dir absent — ignore
+    }
+  }
+  return false;
 }

--- a/hooks/auto-format.mjs
+++ b/hooks/auto-format.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
-// PostToolUse (Write|Edit): auto-fix + format edited source files.
-// Runs eslint --fix then prettier --write on JS/TS files under src/.
-// Never blocks the edit — silently no-ops if tooling is absent or file is out of scope.
+// PostToolUse (Write|Edit): auto-fix + format the edited file with Biome.
+// Biome is one tool for lint-fix + format (replaces eslint + prettier), matching
+// the plus-ultra:tech-stack default. Never blocks the edit — silently no-ops if
+// Biome is absent or the file isn't a JS/TS source.
 import { spawnSync } from "node:child_process";
 import { readInput, debug } from "./_lib.mjs";
 
@@ -11,22 +12,19 @@ debug("auto-format", input);
 const file = String(input?.tool_input?.file_path ?? "");
 if (!file) process.exit(0);
 
-// Scope: files under a src/ directory with a JS/TS extension.
-if (!/(^|\/)src\//.test(file)) process.exit(0);
-if (!/\.(m?[jt]sx?|cts|mts)$/.test(file)) process.exit(0);
+// Scope: JS/TS/JSON source files, anywhere in the repo (monorepo-friendly —
+// apps/**, packages/**, src/**, config files at root all qualify).
+if (!/\.(m?[jt]sx?|cts|mts|json|jsonc)$/.test(file)) process.exit(0);
 
-const run = (bin, args) => {
-  try {
-    spawnSync("npx", ["--no-install", bin, ...args, file], {
-      stdio: "ignore",
-      timeout: 25000,
-    });
-  } catch {
-    // ignore — tooling missing or errored; the edit stands as-is.
-  }
-};
-
-run("eslint", ["--fix"]);
-run("prettier", ["--write"]);
+try {
+  // `biome check --write` runs safe lint fixes + formatting in one pass.
+  // --no-errors-on-unmatched: don't fail if the file is outside Biome's config globs.
+  spawnSync("npx", ["--no-install", "biome", "check", "--write", "--no-errors-on-unmatched", file], {
+    stdio: "ignore",
+    timeout: 25000,
+  });
+} catch {
+  // ignore — Biome missing or errored; the edit stands as-is.
+}
 
 process.exit(0);

--- a/hooks/commit-gate.mjs
+++ b/hooks/commit-gate.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
-// PreToolUse (Bash): block `git commit` unless tests passed this session.
-// Order is flexible — tests may run any time in the session, not necessarily
-// before writing code.
-import { existsSync } from "node:fs";
-import { readInput, debug, deny, allow, stateDir } from "./_lib.mjs";
+// PreToolUse (Bash): block `git commit` unless this session recorded a passing
+// test run — and, in a TypeScript project, a passing typecheck too. Order is
+// flexible: the checks may run any time in the session, not before writing code.
+import { readInput, debug, deny, allow, readMarker, isTsProject } from "./_lib.mjs";
 
 const input = await readInput();
 debug("commit-gate", input);
@@ -13,15 +12,20 @@ const c = cmd.replace(/\s+/g, " ").trim();
 
 // Only gate real commits.
 if (!/\bgit\s+commit\b/.test(c)) allow();
-// Dry runs and message-only edits don't create commits.
+// Dry runs don't create commits.
 if (/--dry-run\b/.test(c)) allow();
 
-const sessionId = String(input?.session_id ?? "default");
-const marker = `${stateDir()}/${sessionId}.json`;
+const root = process.env.CLAUDE_PROJECT_DIR || input?.cwd || process.cwd();
+const marker = readMarker(input?.session_id);
 
-if (existsSync(marker)) allow();
+const missing = [];
+if (!marker.testPassedAt) missing.push("a passing test run (must exit 0)");
+if (isTsProject(root) && !marker.typecheckPassedAt)
+  missing.push("a passing typecheck (e.g. `tsc --noEmit` or your `typecheck` script)");
+
+if (missing.length === 0) allow();
 
 deny(
-  "Blocked by plus-ultra commit-gate: no passing test run recorded this session. " +
-    "Run your test suite (it must exit 0) before committing, then retry the commit."
+  `Blocked by plus-ultra commit-gate: this session is missing ${missing.join(" and ")}. ` +
+    `Run ${missing.length > 1 ? "them" : "it"} (exit 0) before committing, then retry.`
 );

--- a/hooks/commit-msg-lint.mjs
+++ b/hooks/commit-msg-lint.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// PreToolUse (Bash): validate a `git commit -m` header against Conventional
+// Commits (see the plus-ultra:conventional-commits skill). Blocks a malformed
+// header before the commit is created.
+//
+// Only inspects inline `-m` / `--message` commits — if the message comes from an
+// editor or `-F <file>`, the header isn't visible here, so we allow (fail open).
+import { readInput, debug, deny, allow } from "./_lib.mjs";
+
+const input = await readInput();
+debug("commit-msg-lint", input);
+
+const cmd = String(input?.tool_input?.command ?? "");
+const c = cmd.replace(/\s+/g, " ").trim();
+
+// Only gate real commits.
+if (!/\bgit\s+commit\b/.test(c)) allow();
+if (/--dry-run\b/.test(c)) allow();
+
+// Extract the first inline message: -m "…", -am '…', --message=…, --message …
+// Handles short-flag clusters that include m (e.g. -sm, -am) and both quote styles.
+function firstMessage(command) {
+  // --message=VALUE or --message VALUE
+  let m = command.match(/--message[= ]\s*("([^"]*)"|'([^']*)'|(\S+))/);
+  if (m) return m[2] ?? m[3] ?? m[4] ?? "";
+  // short flag cluster containing m, then the value as the next token
+  m = command.match(/(?:^|\s)-[a-z]*m[a-z]*\s+("([^"]*)"|'([^']*)'|(\S+))/i);
+  if (m) return m[2] ?? m[3] ?? m[4] ?? "";
+  return null;
+}
+
+const msg = firstMessage(cmd);
+
+// No inline message (editor / -F) → can't inspect, allow.
+if (msg === null) allow();
+
+const header = msg.split("\n")[0].trim();
+
+// A merge/revert/fixup auto-header is fine.
+if (/^(Merge|Revert|fixup!|squash!)\b/.test(header)) allow();
+
+const TYPES = "feat|fix|docs|refactor|perf|test|build|ci|chore|revert";
+const CONVENTIONAL = new RegExp(`^(${TYPES})(\\([a-z0-9._/-]+\\))?(!)?: .+`);
+
+if (CONVENTIONAL.test(header)) allow();
+
+deny(
+  `Blocked by plus-ultra commit-msg-lint: commit header "${header}" is not a Conventional Commit.\n` +
+    `Expected: type(scope): subject — where type is one of ${TYPES.split("|").join(", ")}.\n` +
+    `Examples: "feat(web): add command palette", "fix(api): reject expired tokens".\n` +
+    `See the plus-ultra:conventional-commits skill.`
+);

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "plus-ultra guardrails: commit-gate, dangerous-command blocking, test-pass tracking, auto-format, spec-aware session resume.",
+  "description": "plus-ultra guardrails: dangerous-command + secret-scan blocking, conventional-commit lint, commit-gate (tests + typecheck), test/typecheck tracking, Biome auto-format, spec-aware session resume.",
   "hooks": {
     "PreToolUse": [
       {
@@ -8,6 +8,16 @@
           {
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/dangerous-command.mjs",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/secret-scan.mjs",
+            "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/commit-msg-lint.mjs",
             "timeout": 10
           },
           {

--- a/hooks/secret-scan.mjs
+++ b/hooks/secret-scan.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// PreToolUse (Bash): before a `git commit`, scan the staged diff for obvious
+// secrets and block if any are found. Deliberate blocker (like commit-gate).
+// Fail open: if git is unavailable or anything errors, allow the commit.
+import { spawnSync } from "node:child_process";
+import { readInput, debug, deny, allow } from "./_lib.mjs";
+
+const input = await readInput();
+debug("secret-scan", input);
+
+const cmd = String(input?.tool_input?.command ?? "");
+const c = cmd.replace(/\s+/g, " ").trim();
+
+if (!/\bgit\s+commit\b/.test(c)) allow();
+if (/--dry-run\b/.test(c)) allow();
+
+const root = process.env.CLAUDE_PROJECT_DIR || input?.cwd || process.cwd();
+
+const git = (args) => {
+  try {
+    const r = spawnSync("git", args, { cwd: root, encoding: "utf8", timeout: 8000 });
+    return r.status === 0 ? String(r.stdout ?? "") : null;
+  } catch {
+    return null;
+  }
+};
+
+const findings = [];
+
+// 1. Staged env files (allow the shareable *.example / *.sample / *.template).
+const staged = git(["diff", "--cached", "--name-only"]);
+if (staged === null) allow(); // no git / not a repo → don't disrupt
+for (const f of staged.split("\n").map((s) => s.trim()).filter(Boolean)) {
+  const base = f.split("/").pop();
+  if (/(^|\.)env(\.|$)/.test(base) && !/\.(example|sample|template|dist)$/.test(base)) {
+    findings.push(`staged env file: ${f}`);
+  }
+}
+
+// 2. Secret-looking tokens in the added lines of the staged diff.
+const diff = git(["diff", "--cached", "--unified=0"]);
+const SECRETS = [
+  [/-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/, "private key block"],
+  [/AKIA[0-9A-Z]{16}/, "AWS access key id"],
+  [/gh[pousr]_[A-Za-z0-9]{36,}/, "GitHub token"],
+  [/xox[baprs]-[A-Za-z0-9-]{10,}/, "Slack token"],
+  [/sk-ant-[A-Za-z0-9-]{20,}/, "Anthropic API key"],
+  [/sk-[A-Za-z0-9]{32,}/, "OpenAI-style secret key"],
+  [/AIza[0-9A-Za-z_-]{35}/, "Google API key"],
+];
+if (diff) {
+  for (const line of diff.split("\n")) {
+    if (!line.startsWith("+") || line.startsWith("+++")) continue;
+    for (const [re, label] of SECRETS) {
+      if (re.test(line)) findings.push(`${label} in added line`);
+    }
+  }
+}
+
+if (findings.length === 0) allow();
+
+const unique = [...new Set(findings)];
+deny(
+  `Blocked by plus-ultra secret-scan: the staged changes look like they contain secrets:\n` +
+    unique.map((f) => `  - ${f}`).join("\n") +
+    `\nUnstage the secret, move it to an env var / secrets manager, and add the file to .gitignore. ` +
+    `If this is a false positive, commit the specific safe paths deliberately.`
+);

--- a/hooks/test-marker.mjs
+++ b/hooks/test-marker.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
-// PostToolUse (Bash): when a test command completes successfully, write a
-// per-session marker that commit-gate reads. Fail-closed: only write on a
-// clear success signal.
-import { mkdirSync, writeFileSync } from "node:fs";
-import { readInput, debug, stateDir } from "./_lib.mjs";
+// PostToolUse (Bash): when a test run OR a typecheck completes successfully,
+// record it in the per-session marker that commit-gate reads. Fail-closed: only
+// record on a clear success signal.
+import { readInput, debug, mergeMarker } from "./_lib.mjs";
 
 const input = await readInput();
 debug("test-marker", input);
@@ -11,16 +10,38 @@ debug("test-marker", input);
 const cmd = String(input?.tool_input?.command ?? "");
 const sessionId = String(input?.session_id ?? "default");
 
-// Does this look like a test-runner invocation?
-const TEST_CMD =
-  /(^|[;&|]\s*)(npx\s+)?(npm\s+(run\s+)?test\b|npm\s+t\b|yarn\s+(run\s+)?test\b|pnpm\s+(run\s+)?test\b|bun\s+test\b|vitest\b|jest\b|mocha\b|node\s+--test\b|ava\b)/;
-if (!TEST_CMD.test(cmd)) process.exit(0);
+// Classify the command: a test runner or a typecheck. Neither → nothing to do.
+// A package-manager prefix may carry flags between the pm and the script
+// (e.g. `pnpm -r test`, `pnpm --filter web typecheck`), so allow flag tokens.
+const PM = "(?:pnpm|npm|yarn|bun)";
+const FLAG = "(?:run|exec|dlx|-{1,2}[\\w:=./-]+|--filter[= ]?\\S+)";
+const PM_PREFIX = `${PM}(?:\\s+${FLAG})*\\s+`;
+const A = "(?:^|[;&|]\\s*)"; // command start or a shell separator
+
+// test runners (may stand alone or under a pm), pm test scripts, or `node --test`
+const TEST_CMD = new RegExp(
+  `${A}(?:` +
+    `(?:npx\\s+)?(?:${PM_PREFIX})?(?:vitest|jest|mocha|ava)\\b` +
+    `|(?:npx\\s+)?${PM_PREFIX}(?:test|t)\\b` +
+    `|node\\s+--test\\b` +
+    `)`
+);
+// tsc/vue-tsc directly, or a pm typecheck script
+const TYPECHECK_CMD = new RegExp(
+  `${A}(?:` +
+    `(?:npx\\s+)?(?:${PM_PREFIX})?(?:tsc|vue-tsc)\\b` +
+    `|(?:npx\\s+)?${PM_PREFIX}(?:typecheck|type-check)\\b` +
+    `)`
+);
+
+const isTest = TEST_CMD.test(cmd);
+const isTypecheck = TYPECHECK_CMD.test(cmd);
+if (!isTest && !isTypecheck) process.exit(0);
 
 // Success detection. tool_response shape is not fully documented, so probe the
 // likely fields in priority order and fail-closed on ambiguity.
 const resp = input?.tool_response ?? {};
-const exit =
-  resp.exitCode ?? resp.exit_code ?? resp.returnCode ?? resp.code ?? undefined;
+const exit = resp.exitCode ?? resp.exit_code ?? resp.returnCode ?? resp.code ?? undefined;
 
 let passed;
 if (input?.tool_error === true || resp.interrupted === true) {
@@ -37,22 +58,19 @@ if (input?.tool_error === true || resp.interrupted === true) {
     /\b\d+\s+(failing|failed)\b/.test(text) ||
     /tests?\s+failed/.test(text) ||
     /\bfail(ed)?\b.*\b(suite|spec|test)/.test(text) ||
+    /error ts\d+:/.test(text) ||
     /npm error|command failed|exit code [1-9]/.test(text);
-  // Require an affirmative pass token AND no failure token.
-  const success = /\b(pass(ed|ing)?|✓|ok\b|\d+\s+passing|tests?\s+passed)\b/.test(text);
+  const success =
+    /\b(pass(ed|ing)?|✓|ok\b|\d+\s+passing|tests?\s+passed)\b/.test(text) ||
+    (isTypecheck && !failure); // typecheck often prints nothing on success
   passed = success && !failure;
 }
 
 if (!passed) process.exit(0);
 
-try {
-  const dir = stateDir();
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(
-    `${dir}/${sessionId}.json`,
-    JSON.stringify({ testPassedAt: new Date().toISOString(), command: cmd }, null, 2)
-  );
-} catch {
-  // Never disrupt the session over a marker write failure.
-}
+const now = new Date().toISOString();
+const patch = {};
+if (isTest) patch.testPassedAt = now;
+if (isTypecheck) patch.typecheckPassedAt = now;
+mergeMarker(sessionId, patch);
 process.exit(0);

--- a/mcp/github.json
+++ b/mcp/github.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/"
-    }
-  }
-}

--- a/skills/conventional-commits/SKILL.md
+++ b/skills/conventional-commits/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: conventional-commits
+description: The commit message format for this repo — Conventional Commits (type(scope): subject). Use whenever writing a git commit message, squashing, or shaping a PR title. Defines the allowed types, scope rules, subject style, body/footer conventions, and how breaking changes are marked. The commit-msg-lint hook enforces the header format on Claude Code.
+---
+
+# plus-ultra commit conventions
+
+Every commit follows [Conventional Commits](https://www.conventionalcommits.org). The header is
+machine-parseable so the changelog and semver bumps derive from history.
+
+## Format
+
+```
+type(scope): subject
+
+[optional body]
+
+[optional footer(s)]
+```
+
+- **Header** — one line, `type(scope): subject`. Keep ≤ 72 chars. This is what the lint hook checks.
+- **Blank line** then optional **body** — the *why*, wrapped ~72 cols. Not the *what* (the diff shows that).
+- **Footer** — `BREAKING CHANGE: …`, or issue refs like `Refs: #12`, `Closes #12`.
+
+## Types
+
+| Type | Use for | semver |
+|---|---|---|
+| `feat` | a new user-facing capability | minor |
+| `fix` | a bug fix | patch |
+| `docs` | docs only | — |
+| `refactor` | code change that isn't a feature or fix | — |
+| `perf` | performance improvement | patch |
+| `test` | adding/fixing tests only | — |
+| `build` | build system, deps, tooling config | — |
+| `ci` | CI config / workflows | — |
+| `chore` | maintenance not covered above | — |
+| `revert` | reverts a prior commit | — |
+
+## Scope
+
+Optional, lowercase, a noun for the area touched. In this harness's monorepo, prefer the workspace
+or module: `feat(web): …`, `fix(api): …`, `refactor(shared): …`, `build(deps): …`. Omit if the change
+is genuinely cross-cutting.
+
+## Subject
+
+- Imperative mood: "add", not "added"/"adds".
+- No leading capital, no trailing period.
+- Say what the change does, concretely: `fix(api): reject expired tokens` not `fix(api): bug fix`.
+
+## Breaking changes
+
+Either append `!` after the type/scope **and** explain in a footer:
+
+```
+feat(api)!: drop the v1 auth routes
+
+BREAKING CHANGE: /v1/auth/* removed; migrate to /v2/session.
+```
+
+## Examples
+
+```
+feat(web): add keyboard nav to the command palette
+fix(api): reject expired session tokens
+refactor(shared): extract the zod user schema
+docs: document the tech-stack defaults
+build(deps): bump drizzle-orm to 0.44
+```
+
+## Fit with plus-ultra
+
+- The **commit-msg-lint** hook (Claude Code) validates the header of `git commit -m` against this
+  format and blocks a malformed message before the commit is created.
+- Types map to `plus-ultra:release`'s changelog sections and semver bump.

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: new-project
+description: Scaffold a new project with the plus-ultra default stack — a pnpm-workspaces monorepo with a React + Vite web app, a Hono API, a shared zod/types package, Biome, vitest, and CI. Use when starting a new repo, bootstrapping an app, or asked to "set up a project" without a stack specified. Reads plus-ultra:tech-stack for the picks.
+---
+
+# plus-ultra new project scaffold
+
+Bootstraps the `plus-ultra:tech-stack` defaults. Confirm the stack with the user first if they
+haven't stated one — this skill fills silence, it doesn't override stated preferences.
+
+## Before scaffolding
+
+- Confirm project name and whether they want the full **monorepo** (default) or a **single package**
+  (throwaway / single-surface). Everything below assumes the monorepo.
+- Fetch current setup commands/versions via Context7 before running init commands — don't rely on
+  memorized CLI flags for Vite, Hono, Drizzle, Biome, etc.
+
+## Target layout
+
+```
+.
+├── package.json            # workspace root: scripts, devDeps (biome, typescript, vitest)
+├── pnpm-workspace.yaml      # packages: apps/*, packages/*
+├── biome.json               # one config for lint + format
+├── tsconfig.base.json       # strict base extended by each workspace
+├── .github/workflows/ci.yml # from this skill's assets/ci.yml
+├── apps/
+│   ├── web/                 # React + Vite + React Router + Tailwind + shadcn/ui
+│   └── api/                 # Hono server + Drizzle (Neon Postgres)
+└── packages/
+    └── shared/              # zod schemas + types imported by BOTH apps
+```
+
+## Steps
+
+1. **Root workspace** — `package.json` (private, `packageManager: pnpm@…`), `pnpm-workspace.yaml`
+   listing `apps/*` and `packages/*`. Root scripts delegate with `pnpm -r`:
+   `typecheck` (`tsc --noEmit` per workspace), `test` (`vitest run`), `lint`/`format` (Biome).
+2. **`tsconfig.base.json`** — `strict: true`, `moduleResolution: bundler`, `noUncheckedIndexedAccess`.
+   Each workspace extends it.
+3. **`packages/shared`** — export zod schemas + inferred types. This is the front↔back contract.
+4. **`apps/api`** — Hono app; validate request bodies with the shared zod schemas; **export the app
+   type** for RPC. Drizzle schema + `@neondatabase/serverless` connection.
+5. **`apps/web`** — Vite + React + React Router; Tailwind + shadcn/ui; typed API calls via Hono's
+   `hc<AppType>` client. Apply the `frontend-design` skill for the visual layer.
+6. **Biome** — `biome.json` at root; wire the plus-ultra `auto-format` hook's tool (it runs
+   `biome check --write` on edited files).
+7. **CI** — copy [`assets/ci.yml`](./assets/ci.yml) to `.github/workflows/ci.yml` (install → Biome
+   ci → typecheck → test).
+8. **Repo conventions** — create `specs/` and `docs/` per `plus-ultra:spec-conventions`; add a
+   `.gitignore` covering `node_modules`, `dist`, `.env*` (keep `.env.example`).
+
+## After scaffolding
+
+- Verify: `pnpm install`, then `pnpm -r typecheck` and `pnpm -r test` exit 0 (also satisfies the
+  commit-gate before the first commit).
+- First commit uses `plus-ultra:conventional-commits` (e.g. `chore: scaffold monorepo`).

--- a/skills/new-project/assets/ci.yml
+++ b/skills/new-project/assets/ci.yml
@@ -1,0 +1,30 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Lint + format check (Biome). `ci` fails on any unformatted/lintable file.
+      - run: pnpm biome ci .
+
+      # Typecheck every workspace (matches the commit-gate typecheck requirement).
+      - run: pnpm -r typecheck
+
+      # Tests.
+      - run: pnpm -r test

--- a/skills/spec-conventions/SKILL.md
+++ b/skills/spec-conventions/SKILL.md
@@ -46,7 +46,9 @@ New specs start from [`template.md`](./template.md). Required sections:
 ## Docs live in `docs/`
 
 - `docs/architecture.md` — system overview, module boundaries, key decisions in prose.
-- `docs/adr/NNN-slug.md` — Architecture Decision Records (one per significant decision, same numbering style).
+- `docs/adr/NNN-slug.md` — Architecture Decision Records (one per significant decision, same
+  numbering style). Start each from [`adr-template.md`](./adr-template.md): Context → Decision →
+  Alternatives considered → Consequences, with a `status:` of proposed → accepted → superseded.
 - `docs/CHANGELOG.md` — user-facing change log, newest first.
 
 ## Workflow fit

--- a/skills/spec-conventions/adr-template.md
+++ b/skills/spec-conventions/adr-template.md
@@ -1,0 +1,27 @@
+---
+status: proposed # proposed | accepted | superseded
+date: YYYY-MM-DD
+supersedes: # ADR number this replaces, if any
+superseded-by: # ADR number that replaces this, if any
+---
+
+# NNN. <short decision title>
+
+## Context
+
+What forces are at play — the technical, product, or team situation that makes a decision necessary.
+State the constraints and the problem, not the answer.
+
+## Decision
+
+The choice made, in one or two sentences, active voice: "We will …".
+
+## Alternatives considered
+
+- **<option>** — why it was rejected (or would have been chosen under different constraints).
+- **<option>** — …
+
+## Consequences
+
+What becomes easier and what becomes harder as a result. Include follow-on work, new constraints,
+and anything a future reader would be surprised by.

--- a/skills/tech-stack/SKILL.md
+++ b/skills/tech-stack/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: tech-stack
+description: The default technology stack for new projects in this harness — a TypeScript-everywhere React + Hono monorepo. Use when starting a new project, scaffolding an app, choosing a framework/library/tool, or when a decision needs a sensible default. States the picks and, for each, when to deviate. Superpowers owns the methodology; this skill owns the defaults.
+---
+
+# plus-ultra default tech stack
+
+Opinionated defaults so a new project starts without re-litigating tooling. **TypeScript on both
+ends, React on the front, Hono on the back, one monorepo, types shared across the boundary.**
+
+These are defaults, not laws. Each row says when to deviate. If the user names a different tool,
+follow the user — this skill only fills silence.
+
+## The stack
+
+| Layer | Default | Deviate when |
+|---|---|---|
+| Repo | **pnpm workspaces monorepo** | truly single-surface throwaway → single package |
+| Language | **TypeScript, `strict: true`**, both ends | never (this harness is TS-first) |
+| Frontend build | **Vite** | — |
+| UI framework | **React** | — |
+| Routing | **React Router** | app is a single view |
+| Styling | **Tailwind CSS** | design system mandates otherwise |
+| Components | **shadcn/ui** | need a heavier component lib (MUI, etc.) |
+| Design guidance | **`frontend-design` skill** | — |
+| Backend framework | **Hono** | need Fastify's plugin ecosystem / pure-Node middleware |
+| Front↔back types | **Hono RPC** (`hc` client) | GraphQL surface → codegen instead |
+| Validation | **zod**, schemas in `packages/shared` | — |
+| Database | **Neon Postgres** | local-only / embedded → SQLite |
+| ORM / query | **Drizzle** | raw SQL is genuinely simpler |
+| Tests | **vitest** | — |
+| Lint + format | **Biome** (one tool, replaces eslint + prettier) | a required plugin only exists for eslint |
+| Package manager | **pnpm** | — |
+| Deploy | **Vercel** (web) + **Fly/Railway** (api) | — |
+
+## Monorepo layout
+
+```
+apps/web           React + Vite + React Router + Tailwind + shadcn/ui
+apps/api           Hono server
+packages/shared    zod schemas + types imported by BOTH apps
+```
+
+The point of TypeScript-on-both-ends is the shared boundary: **define a shape once as a zod schema
+in `packages/shared`**, and both the API (validate input) and the web app (typed fetch via Hono RPC)
+consume it. No duplicated types, no drift. If you find yourself writing the same interface twice,
+move it to `packages/shared`.
+
+## How it connects
+
+- **Hono RPC** — export the Hono app's type from `apps/api`, import it in `apps/web` with `hc<AppType>`.
+  The frontend gets fully-typed routes and payloads with zero codegen.
+- **zod** — every API boundary (request body, params, response) is a zod schema in `packages/shared`.
+  Hono validates with it server-side; the web app infers types from it client-side.
+- **Drizzle + Neon** — Drizzle schema lives in `apps/api`; use `@neondatabase/serverless` for the
+  connection so it works on serverless/edge runtimes.
+
+## Fit with the rest of plus-ultra
+
+- `plus-ultra:new-project` scaffolds this layout.
+- The `auto-format` hook runs **Biome** on edited files — matches this stack's lint/format pick.
+- The `commit-gate` hook requires a passing **vitest** run (and a `tsc` typecheck in TS projects)
+  before commit.
+- `plus-ultra:spec-conventions` governs where specs and ADRs live.


### PR DESCRIPTION
Adds four portable skills — `tech-stack` (a TypeScript monorepo default: React+Vite / Hono / shared zod, Drizzle+Neon, vitest, Biome), `conventional-commits`, `new-project` (scaffold + CI), and an ADR template — plus a `/plus-ultra:spec` lifecycle command. Adds two PreToolUse guardrail hooks: `secret-scan` (blocks staged secrets/`.env`) and `commit-msg-lint` (enforces Conventional Commit headers). Extends `commit-gate` to also require a passing typecheck in TypeScript projects and `test-marker` to track typecheck runs, with a rewritten detector that now handles `pnpm -r` / `--filter` invocations (previously undetected). Switches `auto-format` from eslint+prettier-on-`src/**` to `biome check --write` across the whole repo, matching the new stack. Drops the bundled GitHub MCP in favor of the `gh` CLI, so the plugin now ships zero MCPs.