### PR TITLE
Add Codex plugin hooks and portable workflows

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plus-ultra",
   "version": "0.1.0",
-  "description": "Spec-driven development conventions on top of Superpowers. Portable skill + spec template; the Claude Code build adds guardrail hooks and review subagents.",
+  "description": "Spec-driven development conventions on top of Superpowers, with portable skills and Codex lifecycle hooks for guardrails.",
   "author": {
     "name": "Mauro Cicerchia",
     "email": "maurocicerchia98@gmail.com",
@@ -12,14 +12,18 @@
   "license": "MIT",
   "keywords": ["spec-driven", "tdd", "workflow", "planning"],
   "skills": "./skills/",
-  "hooks": {},
+  "hooks": "./hooks/hooks-codex.json",
   "interface": {
     "displayName": "Plus Ultra",
     "shortDescription": "Spec-driven development conventions for coding agents",
-    "longDescription": "Repo conventions for spec-driven development: specs/NNN-slug.md numbering, a spec template, and a draft -> approved -> in-progress -> done lifecycle. Built to sit on top of Superpowers.",
+    "longDescription": "Repo conventions for spec-driven development: specs/NNN-slug.md numbering, a spec template, and a draft -> approved -> in-progress -> done lifecycle. Includes Codex lifecycle hooks for command guardrails, verification tracking, formatting, and spec-aware session resume. Built to sit on top of Superpowers.",
     "developerName": "Mauro Cicerchia",
     "category": "Developer Tools",
     "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "Create a new plus-ultra spec for this feature.",
+      "Review this branch against the in-progress plus-ultra spec."
+    ],
     "websiteURL": "https://github.com/maurocicerchia/plus-ultra"
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,20 +12,21 @@ own manifest, and they all point at the one shared `skills/` dir.
 ```
 .claude-plugin/marketplace.json  lists superpowers (github) + plus-ultra (./)
 .claude-plugin/plugin.json       Claude manifest; dependencies: ["superpowers"] (array, unpinned)
-.codex-plugin/plugin.json        Codex manifest — skills only, hooks: {}
+.codex-plugin/plugin.json        Codex manifest — skills + hooks/hooks-codex.json
 .cursor-plugin/plugin.json       Cursor manifest — skills only
 .agents/plugins/marketplace.json open-agents ("agents") marketplace entry
 skills/                          portable markdown skills (SKILL.md + assets) — shared by ALL agents
 commands/                        slash commands (*.md) — Claude only
 agents/                          Claude Code subagents (*.md) — Claude only
-hooks/                           hooks.json + zero-dep Node ESM scripts — Claude only
+hooks/                           hooks.json, hooks-codex.json + zero-dep Node ESM scripts
 ```
 
 GitHub access is via the `gh` CLI (no bundled MCP).
 
 ## Conventions
 
-- **Hooks are dependency-free Node ESM** (`.mjs`), invoked as `node ${CLAUDE_PLUGIN_ROOT}/hooks/…`.
+- **Hooks are dependency-free Node ESM** (`.mjs`). Claude invokes them as
+  `node ${CLAUDE_PLUGIN_ROOT}/hooks/…`; Codex invokes them as `node ${PLUGIN_ROOT}/hooks/…`.
   Shared stdin/decision helpers live in `hooks/_lib.mjs`. PreToolUse hooks block by emitting a
   `permissionDecision: "deny"` JSON decision (see `deny()`), never by throwing.
 - **Fail open, never disrupt the session.** A hook that errors or hits missing tooling should exit 0
@@ -40,6 +41,9 @@ GitHub access is via the `gh` CLI (no bundled MCP).
 
 - `claude plugin validate .` (marketplace) and `claude plugin validate ./plus-ultra` (plugin +
   frontmatter/hooks JSON) must pass.
+- Codex packaging should install from a clean temporary `CODEX_HOME`:
+  `CODEX_HOME="$(pwd)/.context/codex-home" codex plugin marketplace add "$(pwd)"`, then
+  `CODEX_HOME="$(pwd)/.context/codex-home" codex plugin add plus-ultra@plus-ultra-dev`.
 - Test hook scripts by piping a sample payload:
   `echo '<json>' | node plus-ultra/hooks/<script>.mjs; echo "exit=$?"`.
   Set `PLUS_ULTRA_HOOK_DEBUG=1` to dump the raw hook payload to stderr.
@@ -48,9 +52,10 @@ GitHub access is via the `gh` CLI (no bundled MCP).
 
 ## Multi-agent
 
-Only the `skills/` dir (portable markdown) ports across agents; every manifest points at it. Hooks
-and subagents are Claude-Code-specific mechanisms, so the Codex/Cursor/agents manifests ship skills
-only (`hooks: {}` or omitted). When editing a skill, remember it must read well for any agent, not
-just Claude — keep Claude-only mechanics (hooks, subagents, `${CLAUDE_PLUGIN_ROOT}`) out of skill
-prose. To add another agent, drop in its `.<agent>-plugin/plugin.json` (or marketplace entry) with
-`"skills": "./skills/"`; don't duplicate skill content.
+Only the `skills/` dir (portable markdown) ports across every agent; every manifest points at it.
+Codex also supports lifecycle hooks, so it ships `hooks/hooks-codex.json`. Claude's slash commands
+and Markdown subagents do not port directly; keep portable equivalents as skills. When editing a
+skill, remember it must read well for any agent, not just Claude — keep Claude-only mechanics
+(hooks, subagents, `${CLAUDE_PLUGIN_ROOT}`) out of skill prose. To add another agent, drop in its
+`.<agent>-plugin/plugin.json` (or marketplace entry) with `"skills": "./skills/"`; don't duplicate
+skill content.

--- a/README.md
+++ b/README.md
@@ -19,17 +19,21 @@ Superpowers is declared as a dependency and installed automatically from the sam
 
 ## What it adds
 
-- **Skills (portable, `plus-ultra:*`):**
+- **Skills (portable, `plus-ultra:*` when installed as a plugin):**
   - *spec-conventions* — `specs/NNN-slug.md` numbering + a spec template (Problem, Goals/Non-goals,
     Acceptance criteria, Interface contracts, Data model, Test plan, Risks) with a `status:` lifecycle
     (draft → approved → in-progress → done). Plus `docs/` layout and an ADR template.
+  - *spec* — portable equivalent of `/plus-ultra:spec`: list specs, create the next-numbered spec,
+    or flip a spec's status.
   - *tech-stack* — the default stack: a TypeScript-everywhere **pnpm-workspaces monorepo** —
     React + Vite (web), Hono (api), shared zod/types, Drizzle + Neon, vitest, Biome. Defaults, with
     a stated escape hatch per row.
   - *conventional-commits* — the commit message format (enforced by the commit-msg-lint hook).
   - *new-project* — scaffolds the tech-stack monorepo + CI.
+  - *repo-explorer*, *code-reviewer*, *dep-auditor* — portable skill equivalents of the Claude
+    subagents.
 - **Slash command:** `/plus-ultra:spec` — list specs, create the next-numbered spec, or flip a
-  spec's status.
+  spec's status. Claude Code only; Codex uses the `plus-ultra:spec` skill instead.
 - **Guardrail hooks:**
   - *dangerous-command* (PreToolUse / Bash) — blocks `rm -rf` and force-pushes to `main`/`master`.
   - *secret-scan* (PreToolUse / `git commit`) — blocks a commit whose staged diff contains a
@@ -38,8 +42,8 @@ Superpowers is declared as a dependency and installed automatically from the sam
   - *commit-gate* (PreToolUse / `git commit`) — blocks unless a test run passed this session (and, in
     a TypeScript project, a typecheck). Order is flexible: checks any time in the session.
   - *test-marker* (PostToolUse / Bash) — records a per-session marker when a test or typecheck exits 0.
-  - *auto-format* (PostToolUse / Write|Edit) — runs `biome check --write` on edited JS/TS/JSON files
-    anywhere in the repo (no-ops if Biome is absent).
+  - *auto-format* (PostToolUse / Write|Edit/apply_patch) — runs `biome check --write` on edited
+    JS/TS/JSON files anywhere in the repo (no-ops if Biome is absent).
   - *session-start* — reports which spec is `in-progress` (and what's approved/draft) so sessions
     resume without re-explaining context.
 - **Subagents:** `repo-explorer` (read-only scan), `code-reviewer` (diff vs the spec's acceptance
@@ -59,10 +63,13 @@ Structured skills-first, like Superpowers: the repo root is the plugin for every
 agent's manifest points at the one shared `skills/` dir. The `spec-conventions` skill (and its
 template) therefore works on Claude Code, Codex, Cursor, and any agent that reads `skills/`.
 
-Guardrail hooks, the slash command, and review subagents are **Claude Code only** — they rely on
-Claude's hook system (`PreToolUse`/`PostToolUse`/`SessionStart`), command, and subagent formats,
-which other agents don't share. The Codex/Cursor manifests ship skills only (`hooks: {}`). To add
-another agent, drop in its `.<agent>-plugin/plugin.json` with `"skills": "./skills/"`.
+Codex ships the shared skills plus `hooks/hooks-codex.json`, which uses Codex's lifecycle hook
+schema and `${PLUGIN_ROOT}`. Claude Code ships `hooks/hooks.json`, which uses Claude's plugin
+environment. Cursor ships skills only.
+
+The slash command in `commands/` and Markdown subagents in `agents/` remain Claude Code formats.
+Codex gets equivalent behavior through the portable `spec`, `repo-explorer`, `code-reviewer`, and
+`dep-auditor` skills.
 
 ## Hook scripts
 
@@ -75,12 +82,13 @@ Hooks are dependency-free Node ESM scripts under `hooks/`. They read the hook JS
 ```
 .claude-plugin/marketplace.json  marketplace: superpowers + plus-ultra (source ./)
 .claude-plugin/plugin.json       Claude manifest; dependencies: ["superpowers"]
-.codex-plugin/plugin.json        Codex manifest (skills only)
+.codex-plugin/plugin.json        Codex manifest (skills + Codex lifecycle hooks)
 .cursor-plugin/plugin.json       Cursor manifest (skills only)
 .agents/plugins/marketplace.json open-agents marketplace entry
-skills/                          portable skills (spec-conventions, tech-stack,
-                                 conventional-commits, new-project) — shared by all agents
+skills/                          portable skills (spec-conventions, spec, tech-stack,
+                                 conventional-commits, new-project, repo-explorer,
+                                 code-reviewer, dep-auditor) — shared by all agents
 commands/spec.md                 /plus-ultra:spec lifecycle command — Claude only
 agents/                          repo-explorer, code-reviewer, dep-auditor — Claude only
-hooks/                           hooks.json + *.mjs — Claude only
+hooks/                           hooks.json, hooks-codex.json + *.mjs
 ```

--- a/hooks/_lib.mjs
+++ b/hooks/_lib.mjs
@@ -41,31 +41,43 @@ export function allow() {
   process.exit(0);
 }
 
+export function isCodexInput(input) {
+  return Boolean(input?.hook_event_name || process.env.PLUGIN_ROOT);
+}
+
+export function projectRoot(input) {
+  return process.env.CLAUDE_PROJECT_DIR || input?.cwd || process.cwd();
+}
+
 // Per-session state dir under the project, created lazily.
-export function stateDir() {
-  const root = process.env.CLAUDE_PROJECT_DIR || process.cwd();
-  return `${root}/.claude/plus-ultra/state`;
+export function stateDir(input) {
+  const root = projectRoot(input);
+  const dir = isCodexInput(input) ? ".codex" : ".claude";
+  return `${root}/${dir}/plus-ultra/state`;
 }
 
 // Per-session marker file (records testPassedAt / typecheckPassedAt).
-export function markerPath(sessionId) {
-  return `${stateDir()}/${String(sessionId || "default")}.json`;
+export function markerPath(sessionId, input) {
+  return `${stateDir(input)}/${String(sessionId || "default")}.json`;
 }
 
 // Read the session marker as an object, or {} if absent/invalid.
-export function readMarker(sessionId) {
+export function readMarker(sessionId, input) {
   try {
-    return JSON.parse(readFileSync(markerPath(sessionId), "utf8"));
+    return JSON.parse(readFileSync(markerPath(sessionId, input), "utf8"));
   } catch {
     return {};
   }
 }
 
 // Merge fields into the session marker. Never throws.
-export function mergeMarker(sessionId, patch) {
+export function mergeMarker(sessionId, patch, input) {
   try {
-    mkdirSync(stateDir(), { recursive: true });
-    writeFileSync(markerPath(sessionId), JSON.stringify({ ...readMarker(sessionId), ...patch }, null, 2));
+    mkdirSync(stateDir(input), { recursive: true });
+    writeFileSync(
+      markerPath(sessionId, input),
+      JSON.stringify({ ...readMarker(sessionId, input), ...patch }, null, 2)
+    );
   } catch {
     // never disrupt the session over a marker write failure
   }
@@ -74,7 +86,7 @@ export function mergeMarker(sessionId, patch) {
 // Does this project use TypeScript? True if a tsconfig.json exists at the root
 // or in any immediate apps/* or packages/* workspace (monorepo layout).
 export function isTsProject(root) {
-  const base = root || process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  const base = typeof root === "object" ? projectRoot(root) : root || process.env.CLAUDE_PROJECT_DIR || process.cwd();
   if (existsSync(`${base}/tsconfig.json`)) return true;
   for (const dir of ["apps", "packages"]) {
     try {

--- a/hooks/auto-format.mjs
+++ b/hooks/auto-format.mjs
@@ -9,22 +9,45 @@ import { readInput, debug } from "./_lib.mjs";
 const input = await readInput();
 debug("auto-format", input);
 
-const file = String(input?.tool_input?.file_path ?? "");
-if (!file) process.exit(0);
+function patchFiles(patch) {
+  const files = [];
+  for (const line of String(patch ?? "").split("\n")) {
+    const match = line.match(/^\*\*\* (?:Add|Update) File: (.+)$/);
+    if (match) files.push(match[1].trim());
+  }
+  return files;
+}
+
+function targetFiles(payload) {
+  const toolInput = payload?.tool_input;
+  const files = [];
+
+  if (toolInput?.file_path) files.push(String(toolInput.file_path));
+
+  if (payload?.tool_name === "apply_patch") {
+    if (typeof toolInput === "string") files.push(...patchFiles(toolInput));
+    if (typeof toolInput?.patch === "string") files.push(...patchFiles(toolInput.patch));
+  }
+
+  return [...new Set(files)];
+}
 
 // Scope: JS/TS/JSON source files, anywhere in the repo (monorepo-friendly —
 // apps/**, packages/**, src/**, config files at root all qualify).
-if (!/\.(m?[jt]sx?|cts|mts|json|jsonc)$/.test(file)) process.exit(0);
+const files = targetFiles(input).filter((file) => /\.(m?[jt]sx?|cts|mts|json|jsonc)$/.test(file));
+if (files.length === 0) process.exit(0);
 
-try {
-  // `biome check --write` runs safe lint fixes + formatting in one pass.
-  // --no-errors-on-unmatched: don't fail if the file is outside Biome's config globs.
-  spawnSync("npx", ["--no-install", "biome", "check", "--write", "--no-errors-on-unmatched", file], {
-    stdio: "ignore",
-    timeout: 25000,
-  });
-} catch {
-  // ignore — Biome missing or errored; the edit stands as-is.
+for (const file of files) {
+  try {
+    // `biome check --write` runs safe lint fixes + formatting in one pass.
+    // --no-errors-on-unmatched: don't fail if the file is outside Biome's config globs.
+    spawnSync("npx", ["--no-install", "biome", "check", "--write", "--no-errors-on-unmatched", file], {
+      stdio: "ignore",
+      timeout: 25000,
+    });
+  } catch {
+    // ignore — Biome missing or errored; the edit stands as-is.
+  }
 }
 
 process.exit(0);

--- a/hooks/commit-gate.mjs
+++ b/hooks/commit-gate.mjs
@@ -2,7 +2,7 @@
 // PreToolUse (Bash): block `git commit` unless this session recorded a passing
 // test run — and, in a TypeScript project, a passing typecheck too. Order is
 // flexible: the checks may run any time in the session, not before writing code.
-import { readInput, debug, deny, allow, readMarker, isTsProject } from "./_lib.mjs";
+import { readInput, debug, deny, allow, readMarker, isTsProject, projectRoot } from "./_lib.mjs";
 
 const input = await readInput();
 debug("commit-gate", input);
@@ -15,8 +15,8 @@ if (!/\bgit\s+commit\b/.test(c)) allow();
 // Dry runs don't create commits.
 if (/--dry-run\b/.test(c)) allow();
 
-const root = process.env.CLAUDE_PROJECT_DIR || input?.cwd || process.cwd();
-const marker = readMarker(input?.session_id);
+const root = projectRoot(input);
+const marker = readMarker(input?.session_id, input);
 
 const missing = [];
 if (!marker.testPassedAt) missing.push("a passing test run (must exit 0)");

--- a/hooks/hooks-codex.json
+++ b/hooks/hooks-codex.json
@@ -1,0 +1,73 @@
+{
+  "description": "plus-ultra Codex guardrails: dangerous-command + secret-scan blocking, conventional-commit lint, commit-gate, test/typecheck tracking, Biome auto-format, spec-aware session resume.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${PLUGIN_ROOT}/hooks/dangerous-command.mjs",
+            "timeout": 10,
+            "statusMessage": "Checking dangerous command policy"
+          },
+          {
+            "type": "command",
+            "command": "node ${PLUGIN_ROOT}/hooks/secret-scan.mjs",
+            "timeout": 15,
+            "statusMessage": "Scanning staged changes for secrets"
+          },
+          {
+            "type": "command",
+            "command": "node ${PLUGIN_ROOT}/hooks/commit-msg-lint.mjs",
+            "timeout": 10,
+            "statusMessage": "Checking commit message"
+          },
+          {
+            "type": "command",
+            "command": "node ${PLUGIN_ROOT}/hooks/commit-gate.mjs",
+            "timeout": 10,
+            "statusMessage": "Checking test and typecheck gate"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${PLUGIN_ROOT}/hooks/test-marker.mjs",
+            "timeout": 10,
+            "statusMessage": "Recording verification status"
+          }
+        ]
+      },
+      {
+        "matcher": "apply_patch|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${PLUGIN_ROOT}/hooks/auto-format.mjs",
+            "timeout": 30,
+            "statusMessage": "Formatting edited source files"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${PLUGIN_ROOT}/hooks/session-start.mjs",
+            "timeout": 10,
+            "statusMessage": "Loading spec status"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/secret-scan.mjs
+++ b/hooks/secret-scan.mjs
@@ -3,7 +3,7 @@
 // secrets and block if any are found. Deliberate blocker (like commit-gate).
 // Fail open: if git is unavailable or anything errors, allow the commit.
 import { spawnSync } from "node:child_process";
-import { readInput, debug, deny, allow } from "./_lib.mjs";
+import { readInput, debug, deny, allow, projectRoot } from "./_lib.mjs";
 
 const input = await readInput();
 debug("secret-scan", input);
@@ -14,7 +14,7 @@ const c = cmd.replace(/\s+/g, " ").trim();
 if (!/\bgit\s+commit\b/.test(c)) allow();
 if (/--dry-run\b/.test(c)) allow();
 
-const root = process.env.CLAUDE_PROJECT_DIR || input?.cwd || process.cwd();
+const root = projectRoot(input);
 
 const git = (args) => {
   try {

--- a/hooks/session-start.mjs
+++ b/hooks/session-start.mjs
@@ -3,12 +3,12 @@
 // (and what's next up) so a session resumes without re-explaining context.
 // stdout is injected into the session context.
 import { readdirSync, readFileSync } from "node:fs";
-import { readInput, debug } from "./_lib.mjs";
+import { readInput, debug, isCodexInput, projectRoot } from "./_lib.mjs";
 
 const input = await readInput();
 debug("session-start", input);
 
-const root = process.env.CLAUDE_PROJECT_DIR || input?.cwd || process.cwd();
+const root = projectRoot(input);
 const specsDir = `${root}/specs`;
 
 let files;
@@ -44,6 +44,19 @@ if (buckets.approved.length) lines.push(`Approved (ready to start): ${buckets.ap
 if (buckets.draft.length) lines.push(`Drafts: ${buckets.draft.join(", ")}`);
 
 if (lines.length) {
-  process.stdout.write("plus-ultra spec status:\n" + lines.map((l) => `  - ${l}`).join("\n") + "\n");
+  const context = "plus-ultra spec status:\n" + lines.map((l) => `  - ${l}`).join("\n") + "\n";
+
+  if (isCodexInput(input)) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "SessionStart",
+          additionalContext: context,
+        },
+      })
+    );
+  } else {
+    process.stdout.write(context);
+  }
 }
 process.exit(0);

--- a/hooks/test-marker.mjs
+++ b/hooks/test-marker.mjs
@@ -72,5 +72,5 @@ const now = new Date().toISOString();
 const patch = {};
 if (isTest) patch.testPassedAt = now;
 if (isTypecheck) patch.typecheckPassedAt = now;
-mergeMarker(sessionId, patch);
+mergeMarker(sessionId, patch, input);
 process.exit(0);

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-reviewer
+description: Review the current branch's diff against the acceptance criteria of the in-progress plus-ultra spec. Use before opening a PR or marking a spec done. Reports substantiated findings and does not modify code.
+---
+
+# plus-ultra code reviewer
+
+Review the current branch for a spec-driven Node/TypeScript project.
+
+## Process
+
+1. Identify the in-progress spec by scanning `specs/*.md` for `status: in-progress`.
+2. Read that spec's `Acceptance criteria`, `Interface contracts`, and `Test plan` sections.
+3. Get the current branch diff with `git diff --merge-base main`.
+4. If that fails or is empty when changes are expected, fall back to `git diff origin/main...` or `git diff main...`.
+5. Read changed files for context where the diff alone is unclear.
+6. Check each acceptance criterion: met, partially met, or missing.
+7. Look for correctness risks: unhandled errors, edge cases named in `Risks`, missing tests from the `Test plan`, and interface mismatches against declared contracts.
+
+## Output
+
+- **Acceptance criteria:** checklist with each item marked met, partial, or missing, with a one-line reason and `path:line`.
+- **Correctness findings:** most severe first, each with a concrete failure scenario.
+- **Verdict:** ready or not ready to mark done, with blocking items.
+
+Do not modify files. Be specific and cite `path:line`. Only report issues you can substantiate from the diff or code.

--- a/skills/conventional-commits/SKILL.md
+++ b/skills/conventional-commits/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conventional-commits
-description: The commit message format for this repo — Conventional Commits (type(scope): subject). Use whenever writing a git commit message, squashing, or shaping a PR title. Defines the allowed types, scope rules, subject style, body/footer conventions, and how breaking changes are marked. The commit-msg-lint hook enforces the header format on Claude Code.
+description: "The commit message format for this repo — Conventional Commits (type(scope): subject). Use whenever writing a git commit message, squashing, or shaping a PR title. Defines the allowed types, scope rules, subject style, body/footer conventions, and how breaking changes are marked. The commit-msg-lint hook enforces the header format on Claude Code."
 ---
 
 # plus-ultra commit conventions

--- a/skills/dep-auditor/SKILL.md
+++ b/skills/dep-auditor/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: dep-auditor
+description: Sanity-check newly added npm dependencies before commit. Use when package.json changes introduce dependencies or when reviewing a diff that adds packages. Checks necessity, health, advisories, license, and weight without modifying files.
+---
+
+# plus-ultra dependency auditor
+
+Vet new npm dependencies before they are committed.
+
+For each new or changed dependency, compare `package.json` against git or use the package names the user gives you.
+
+Check:
+
+- **Necessity:** Is there already a dependency or small local utility that does this? Flag packages trivial enough to inline.
+- **Health:** Use `npm view <pkg>` for latest version, last publish date, maintainers, and repository. Note stale or pre-1.0 packages.
+- **Security:** Run `npm audit` if a lockfile exists and report known advisories.
+- **License:** Report the SPDX license and flag copyleft or unusual licenses.
+- **Weight:** Report transitive dependency count or install size when readily available.
+
+Output a short table: package, verdict (`ok`, `caution`, or `avoid`), and one-line reason. Then list any package you recommend replacing or removing.
+
+Do not install packages or modify files.

--- a/skills/repo-explorer/SKILL.md
+++ b/skills/repo-explorer/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: repo-explorer
+description: Read-only codebase scanner for plus-ultra projects. Use to map repo structure, find where something is implemented, or trace a code path without dumping large file contents. Reports concise findings and does not modify files.
+---
+
+# plus-ultra repo explorer
+
+You are a read-only repository explorer for a spec-driven Node/TypeScript project.
+
+Answer the user's question about the codebase by searching and reading, then return a tight summary instead of raw file contents.
+
+Guidelines:
+
+- Do not modify files.
+- Prefer `rg` or file search to locate relevant code, then read only the spans needed.
+- Report findings as: what you looked for, where it lives (`path:line`), and the conclusion.
+- Note existing utilities or patterns the caller could reuse.
+- If the answer is not in the repo, say so plainly rather than guessing.
+- Keep the response scannable with short sections, file references, and no filler.

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: spec
+description: "Manage the plus-ultra spec lifecycle under specs/: list specs by status, create the next numbered spec from the template, or update a spec's status. Use when the user asks for the plus-ultra spec command, wants a new spec, wants to list specs, or wants to move a spec through draft, approved, in-progress, and done."
+---
+
+# plus-ultra spec lifecycle
+
+Use this skill as the portable equivalent of Claude Code's `/plus-ultra:spec` command.
+
+Follow `plus-ultra:spec-conventions` for numbering and lifecycle rules.
+
+## Supported requests
+
+### List specs
+
+For `list`, or when no specific action is given:
+
+1. Scan `specs/*.md`.
+2. Read each file's `status:` frontmatter.
+3. Print a grouped summary in this order:
+   `In progress`, `Approved`, `Drafts`, `Done`.
+4. Note if more than one spec is `in-progress`; normally only one should be.
+
+### Create a new spec
+
+For `new <slug>`:
+
+1. Find the highest existing `NNN` prefix in `specs/` and add one. Use zero-padded three-digit numbers. Never reuse numbers.
+2. Copy `skills/spec-conventions/template.md` into `specs/NNN-<slug>.md`.
+3. Set `status: draft`.
+4. Fill in the title from the slug.
+5. Leave the section prompts for the user to complete.
+6. Report the created path.
+
+### Update status
+
+For `status <NNN|slug> <draft|approved|in-progress|done>`:
+
+1. Resolve the spec file by number or slug.
+2. Validate the transition against `draft -> approved -> in-progress -> done`.
+3. Warn, but do not hard-block, on a skip or reversal; the user may have a reason.
+4. If moving a spec to `in-progress` while another spec is already `in-progress`, call that out and confirm before editing.
+5. Edit only the `status:` field in the frontmatter.
+6. Report the change.
+
+If the user's request does not match one of these forms, explain the three supported forms and stop.

--- a/tests/hooks.test.mjs
+++ b/tests/hooks.test.mjs
@@ -1,0 +1,131 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const repoRoot = new URL("..", import.meta.url).pathname;
+
+function runHook(script, payload, options = {}) {
+  const result = spawnSync(process.execPath, [join(repoRoot, "hooks", script)], {
+    cwd: options.cwd ?? repoRoot,
+    input: JSON.stringify(payload),
+    encoding: "utf8",
+    env: { ...process.env, ...(options.env ?? {}) },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+function makeTempProject() {
+  const root = mkdtempSync(join(tmpdir(), "plus-ultra-test-"));
+  mkdirSync(join(root, "specs"), { recursive: true });
+  writeFileSync(
+    join(root, "specs", "001-codex-hooks.md"),
+    "---\nstatus: in-progress\n---\n# Codex hooks\n"
+  );
+  return root;
+}
+
+test("session-start emits Codex additional context JSON", () => {
+  const cwd = makeTempProject();
+  try {
+    const stdout = runHook(
+      "session-start.mjs",
+      {
+        hook_event_name: "SessionStart",
+        cwd,
+        model: "gpt-5.5",
+        permission_mode: "default",
+        session_id: "session-1",
+        transcript_path: null,
+        turn_id: "turn-1",
+      },
+      { cwd }
+    );
+
+    const output = JSON.parse(stdout);
+    assert.equal(output.hookSpecificOutput.hookEventName, "SessionStart");
+    assert.match(output.hookSpecificOutput.additionalContext, /plus-ultra spec status:/);
+    assert.match(output.hookSpecificOutput.additionalContext, /001-codex-hooks\.md/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("auto-format formats files from Codex apply_patch payloads", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "plus-ultra-format-"));
+  const binDir = join(cwd, "bin");
+  const logPath = join(cwd, "npx-args.json");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(
+    join(binDir, "npx"),
+    `#!/usr/bin/env node\nimport { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(logPath)}, JSON.stringify(process.argv.slice(2)));\n`
+  );
+  spawnSync("chmod", ["+x", join(binDir, "npx")]);
+
+  try {
+    runHook(
+      "auto-format.mjs",
+      {
+        hook_event_name: "PostToolUse",
+        cwd,
+        model: "gpt-5.5",
+        permission_mode: "default",
+        session_id: "session-1",
+        tool_name: "apply_patch",
+        tool_input:
+          "*** Begin Patch\n*** Update File: src/app.ts\n@@\n-old\n+new\n*** End Patch\n",
+        tool_response: { exitCode: 0 },
+        tool_use_id: "tool-1",
+        transcript_path: null,
+        turn_id: "turn-1",
+      },
+      { cwd, env: { PATH: `${binDir}:${process.env.PATH}` } }
+    );
+
+    const args = JSON.parse(readFileSync(logPath, "utf8"));
+    assert.deepEqual(args, [
+      "--no-install",
+      "biome",
+      "check",
+      "--write",
+      "--no-errors-on-unmatched",
+      "src/app.ts",
+    ]);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("test marker writes Codex session state under .codex", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "plus-ultra-marker-"));
+  try {
+    runHook(
+      "test-marker.mjs",
+      {
+        hook_event_name: "PostToolUse",
+        cwd,
+        model: "gpt-5.5",
+        permission_mode: "default",
+        session_id: "session-1",
+        tool_name: "Bash",
+        tool_input: { command: "pnpm test" },
+        tool_response: { exitCode: 0 },
+        tool_use_id: "tool-1",
+        transcript_path: null,
+        turn_id: "turn-1",
+      },
+      { cwd }
+    );
+
+    const marker = JSON.parse(
+      readFileSync(join(cwd, ".codex", "plus-ultra", "state", "session-1.json"), "utf8")
+    );
+    assert.equal(typeof marker.testPassedAt, "string");
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
Add Codex plugin support by wiring `.codex-plugin/plugin.json` to a Codex-specific lifecycle hook config and adapting the existing hook scripts for Codex payloads and state paths. Add portable skills for the spec command and Claude subagent workflows so Codex can use equivalent behavior through skills. Update README/AGENTS documentation for the new multi-agent support boundaries and add Node hook tests for SessionStart context, apply_patch formatting, and Codex verification markers.

## Verification
- node --test tests/hooks.test.mjs
- claude plugin validate .claude-plugin/plugin.json
- claude plugin validate .
- clean isolated Codex plugin marketplace add/install