### PR TITLE
feat(skills): add PR description guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Superpowers is declared as a dependency and installed automatically from the sam
     React + Vite (web), Hono (api), shared zod/types, Drizzle + Neon, vitest, Biome. Defaults, with
     a stated escape hatch per row.
   - *conventional-commits* — the commit message format (enforced by the commit-msg-lint hook).
+  - *pull-request-descriptions* — drafts reviewer-focused PR bodies that connect context, summary,
+    testing, risks, and review guidance.
   - *new-project* — scaffolds the tech-stack monorepo + CI.
   - *repo-explorer*, *code-reviewer*, *dep-auditor* — portable skill equivalents of the Claude
     subagents.
@@ -86,8 +88,9 @@ Hooks are dependency-free Node ESM scripts under `hooks/`. They read the hook JS
 .cursor-plugin/plugin.json       Cursor manifest (skills only)
 .agents/plugins/marketplace.json open-agents marketplace entry
 skills/                          portable skills (spec-conventions, spec, tech-stack,
-                                 conventional-commits, new-project, repo-explorer,
-                                 code-reviewer, dep-auditor) — shared by all agents
+                                 conventional-commits, pull-request-descriptions,
+                                 new-project, repo-explorer, code-reviewer, dep-auditor) —
+                                 shared by all agents
 commands/spec.md                 /plus-ultra:spec lifecycle command — Claude only
 agents/                          repo-explorer, code-reviewer, dep-auditor — Claude only
 hooks/                           hooks.json, hooks-codex.json + *.mjs

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Superpowers is declared as a dependency and installed automatically from the sam
   - *commit-gate* (PreToolUse / `git commit`) — blocks unless a test run passed this session (and, in
     a TypeScript project, a typecheck). Order is flexible: checks any time in the session.
   - *test-marker* (PostToolUse / Bash) — records a per-session marker when a test or typecheck exits 0.
+  - *pr-description-reminder* (PostToolUse / `git commit`) — reminds you to refresh an open PR
+    description after new commits; it never edits GitHub state.
   - *auto-format* (PostToolUse / Write|Edit/apply_patch) — runs `biome check --write` on edited
     JS/TS/JSON files anywhere in the repo (no-ops if Biome is absent).
   - *session-start* — reports which spec is `in-progress` (and what's approved/draft) so sessions

--- a/hooks/hooks-codex.json
+++ b/hooks/hooks-codex.json
@@ -1,5 +1,5 @@
 {
-  "description": "plus-ultra Codex guardrails: dangerous-command + secret-scan blocking, conventional-commit lint, commit-gate, test/typecheck tracking, Biome auto-format, spec-aware session resume.",
+  "description": "plus-ultra Codex guardrails: dangerous-command + secret-scan blocking, conventional-commit lint, commit-gate, test/typecheck tracking, PR description reminders, Biome auto-format, spec-aware session resume.",
   "hooks": {
     "PreToolUse": [
       {
@@ -41,6 +41,12 @@
             "command": "node ${PLUGIN_ROOT}/hooks/test-marker.mjs",
             "timeout": 10,
             "statusMessage": "Recording verification status"
+          },
+          {
+            "type": "command",
+            "command": "node ${PLUGIN_ROOT}/hooks/pr-description-reminder.mjs",
+            "timeout": 10,
+            "statusMessage": "Checking PR description freshness"
           }
         ]
       },

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "plus-ultra guardrails: dangerous-command + secret-scan blocking, conventional-commit lint, commit-gate (tests + typecheck), test/typecheck tracking, Biome auto-format, spec-aware session resume.",
+  "description": "plus-ultra guardrails: dangerous-command + secret-scan blocking, conventional-commit lint, commit-gate (tests + typecheck), test/typecheck tracking, PR description reminders, Biome auto-format, spec-aware session resume.",
   "hooks": {
     "PreToolUse": [
       {
@@ -35,6 +35,11 @@
           {
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/test-marker.mjs",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pr-description-reminder.mjs",
             "timeout": 10
           }
         ]

--- a/hooks/pr-description-reminder.mjs
+++ b/hooks/pr-description-reminder.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// PostToolUse (Bash): after a successful `git commit`, remind the agent to
+// review the open PR description. This hook never edits GitHub state.
+import { spawnSync } from "node:child_process";
+import { readInput, debug, mergeMarker, readMarker } from "./_lib.mjs";
+
+const input = await readInput();
+debug("pr-description-reminder", input);
+
+function toolCommand(payload) {
+  return String(payload?.tool_input?.command ?? "").replace(/\s+/g, " ").trim();
+}
+
+function commandSucceeded(payload) {
+  const resp = payload?.tool_response ?? {};
+  const exit = resp.exitCode ?? resp.exit_code ?? resp.returnCode ?? resp.code;
+  return payload?.tool_error !== true && resp.interrupted !== true && exit === 0;
+}
+
+function run(command, args, cwd) {
+  try {
+    const result = spawnSync(command, args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    if (result.status !== 0) return null;
+    return result.stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+const cmd = toolCommand(input);
+if (!/\bgit\s+commit\b/.test(cmd) || /--dry-run\b/.test(cmd)) process.exit(0);
+if (!commandSucceeded(input)) process.exit(0);
+
+const cwd = input?.cwd || process.cwd();
+const head = run("git", ["rev-parse", "--short", "HEAD"], cwd);
+if (!head) process.exit(0);
+
+const marker = readMarker(input?.session_id, input);
+if (marker.prDescriptionReminderHead === head) process.exit(0);
+
+const prJson = run("gh", ["pr", "view", "--json", "number,url"], cwd);
+if (!prJson) process.exit(0);
+
+let pr;
+try {
+  pr = JSON.parse(prJson);
+} catch {
+  process.exit(0);
+}
+
+if (!pr?.number || !pr?.url) process.exit(0);
+
+mergeMarker(
+  input?.session_id,
+  {
+    prDescriptionReminderHead: head,
+    prDescriptionReminderPr: pr.number,
+    prDescriptionReminderAt: new Date().toISOString(),
+  },
+  input
+);
+
+process.stdout.write(
+  `PR #${pr.number} may need a description update after ${head}. ` +
+    `Use pull-request-descriptions and gh pr edit: ${pr.url}\n`
+);

--- a/skills/pull-request-descriptions/SKILL.md
+++ b/skills/pull-request-descriptions/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: pull-request-descriptions
+description: "Use when drafting, revising, or reviewing pull request descriptions, GitHub PR bodies, merge request summaries, release-oriented change notes, or PR templates before opening or updating a PR."
+---
+
+# Pull Request Descriptions
+
+## Overview
+
+Write PR descriptions as a reviewer handoff, not a changelog. A good body explains why the change
+exists, what behavior changed, how it was verified, and where reviewers should focus.
+
+## Workflow
+
+1. Gather source material before writing:
+   - `git diff origin/main...` or the target branch named by the user
+   - related spec, issue, design doc, or acceptance criteria when present
+   - test, lint, typecheck, build, or manual verification output from this branch
+2. Separate facts from inference. If the diff does not prove something, phrase it as an assumption
+   or omit it.
+3. Write for the reviewer who has not followed the implementation.
+4. Keep the body concise, but do not hide risk, missing verification, or follow-up work.
+
+## Recommended Template
+
+Use this shape unless the repository has its own required PR template:
+
+```markdown
+## Context
+[Why this change is needed. Link or name the spec/issue when applicable.]
+
+## Summary
+- [User-visible or maintainer-visible change]
+- [Important implementation boundary or behavior change]
+
+## Testing
+- [Command or manual check run, with result]
+
+## Risks
+- [Risk, migration concern, rollout note, or "None known" if genuinely low risk]
+
+## Review Guidance
+- [Files, flows, edge cases, or decisions reviewers should inspect first]
+```
+
+## Section Guidance
+
+**Context:** Explain the problem and intent in one short paragraph. Avoid repeating the branch name
+or commit subject. If this PR implements a spec, mention the spec path and status.
+
+**Summary:** Prefer bullets that describe externally meaningful behavior or durable code boundaries.
+Avoid file-by-file narration unless the file organization is the point of the PR.
+
+**Testing:** List only verification that actually ran. Include commands exactly enough to be
+reproducible, for example `pnpm test` or `node --test tests/hooks.test.mjs`. Say "Not run" with a
+reason instead of implying coverage that does not exist.
+
+**Risks:** Name compatibility, migration, security, data, performance, concurrency, release, and UX
+risks. If there are no notable risks, use `None known` rather than deleting the section.
+
+**Review Guidance:** Point reviewers at the highest-leverage questions: tricky logic, public
+interfaces, untested paths, copied patterns, generated files, or intentional non-goals.
+
+## Quality Bar
+
+- Lead with the user's or maintainer's reason for caring.
+- Tie claims to diff evidence, issue text, specs, or verification output.
+- Mention behavior changes before implementation details.
+- Keep status honest: incomplete verification, skipped tests, and known risks belong in the body.
+- Remove process noise such as "this PR simply" or "just updates".
+
+## Common Mistakes
+
+- **Only summarizing commits:** Rewrite around user-facing outcome, architecture boundary, and review
+  intent.
+- **Overstating validation:** Replace vague claims with exact commands or `Not run`.
+- **Burying risk:** Keep risks visible even when they are acceptable.
+- **Repeating the diff:** Do not list every changed file. Explain why the set of changes hangs
+  together.
+- **Ignoring the repo template:** If `.github/pull_request_template.md` or a platform-provided
+  template exists, preserve its required headings and improve the content inside them.
+
+## Before Opening or Updating
+
+Re-read the final body once as the reviewer. Check that the title and description agree, every test
+claim is true, known limitations are visible, and the requested review focus is specific enough to
+act on.

--- a/skills/pull-request-descriptions/agents/openai.yaml
+++ b/skills/pull-request-descriptions/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Pull Request Descriptions"
+  short_description: "Draft reviewer-focused PR descriptions"
+  default_prompt: "Draft a clear pull request description for the current branch."

--- a/tests/hooks.test.mjs
+++ b/tests/hooks.test.mjs
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -6,6 +6,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const repoRoot = new URL("..", import.meta.url).pathname;
+
+function readRelative(path) {
+  return readFileSync(join(repoRoot, path), "utf8");
+}
 
 function runHook(script, payload, options = {}) {
   const result = spawnSync(process.execPath, [join(repoRoot, "hooks", script)], {
@@ -128,4 +132,68 @@ test("test marker writes Codex session state under .codex", () => {
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }
+});
+
+test("PR description reminder emits once after a successful commit with an open PR", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "plus-ultra-pr-reminder-"));
+  const binDir = join(cwd, "bin");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(
+    join(binDir, "git"),
+    `#!/usr/bin/env node\nif (process.argv.slice(2).join(" ") === "rev-parse --short HEAD") {\n  process.stdout.write("abc1234\\n");\n  process.exit(0);\n}\nprocess.exit(1);\n`
+  );
+  writeFileSync(
+    join(binDir, "gh"),
+    `#!/usr/bin/env node\nif (process.argv.slice(2).join(" ") === "pr view --json number,url") {\n  process.stdout.write(JSON.stringify({ number: 4, url: "https://github.com/acme/repo/pull/4" }));\n  process.exit(0);\n}\nprocess.exit(1);\n`
+  );
+  spawnSync("chmod", ["+x", join(binDir, "git")]);
+  spawnSync("chmod", ["+x", join(binDir, "gh")]);
+
+  const payload = {
+    hook_event_name: "PostToolUse",
+    cwd,
+    model: "gpt-5.5",
+    permission_mode: "default",
+    session_id: "session-1",
+    tool_name: "Bash",
+    tool_input: { command: "git commit -m 'feat: add thing'" },
+    tool_response: { exitCode: 0 },
+    tool_use_id: "tool-1",
+    transcript_path: null,
+    turn_id: "turn-1",
+  };
+
+  try {
+    const stdout = runHook("pr-description-reminder.mjs", payload, {
+      cwd,
+      env: { PATH: `${binDir}:${process.env.PATH}` },
+    });
+
+    assert.match(stdout, /PR #4 may need a description update after abc1234/);
+    assert.match(stdout, /pull-request-descriptions/);
+    assert.match(stdout, /gh pr edit/);
+
+    const marker = JSON.parse(
+      readFileSync(join(cwd, ".codex", "plus-ultra", "state", "session-1.json"), "utf8")
+    );
+    assert.equal(marker.prDescriptionReminderHead, "abc1234");
+    assert.equal(marker.prDescriptionReminderPr, 4);
+
+    const second = runHook("pr-description-reminder.mjs", payload, {
+      cwd,
+      env: { PATH: `${binDir}:${process.env.PATH}` },
+    });
+    assert.equal(second, "");
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("hook manifests include PR description reminder after Bash commands", () => {
+  const codexHooks = readRelative("hooks/hooks-codex.json");
+  const claudeHooks = readRelative("hooks/hooks.json");
+
+  assert.match(codexHooks, /pr-description-reminder\.mjs/);
+  assert.match(claudeHooks, /pr-description-reminder\.mjs/);
+  assert.ok(existsSync(join(repoRoot, "hooks", "pr-description-reminder.mjs")));
 });

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -1,0 +1,56 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const repoRoot = new URL("..", import.meta.url).pathname;
+
+function readRelative(path) {
+  return readFileSync(join(repoRoot, path), "utf8");
+}
+
+function parseFrontmatter(markdown) {
+  const match = markdown.match(/^---\n([\s\S]*?)\n---\n/);
+  assert.ok(match, "skill has YAML frontmatter");
+
+  return Object.fromEntries(
+    match[1]
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const separator = line.indexOf(":");
+        assert.notEqual(separator, -1, `frontmatter line has key/value: ${line}`);
+        const key = line.slice(0, separator).trim();
+        const value = line
+          .slice(separator + 1)
+          .trim()
+          .replace(/^"(.*)"$/, "$1");
+        return [key, value];
+      })
+  );
+}
+
+test("pull-request-descriptions skill is packaged and discoverable", () => {
+  const skillPath = "skills/pull-request-descriptions/SKILL.md";
+  assert.ok(existsSync(join(repoRoot, skillPath)), `${skillPath} exists`);
+
+  const skill = readRelative(skillPath);
+  const frontmatter = parseFrontmatter(skill);
+
+  assert.equal(frontmatter.name, "pull-request-descriptions");
+  assert.match(frontmatter.description, /Use when/i);
+  assert.match(frontmatter.description, /pull request|PR/i);
+
+  for (const expectedSection of [
+    "Context",
+    "Summary",
+    "Testing",
+    "Risks",
+    "Review Guidance",
+  ]) {
+    assert.match(skill, new RegExp(expectedSection, "i"));
+  }
+
+  const readme = readRelative("README.md");
+  assert.match(readme, /pull-request-descriptions/);
+});


### PR DESCRIPTION
## Context
Adds portable guidance for drafting clearer PR descriptions and a reminder hook so open PR bodies stay current after follow-up commits.

## Summary
- Adds the `pull-request-descriptions` skill with OpenAI UI metadata and README discovery.
- Adds a non-mutating `pr-description-reminder` hook wired into Claude and Codex PostToolUse Bash hooks.
- Adds Node tests for skill packaging/discovery and the PR reminder behavior.

## Testing
- `node --test tests/*.test.mjs`
- `claude plugin validate . && claude plugin validate .claude-plugin/plugin.json`

## Risks
None known; the reminder hook fails open and never edits GitHub state.