### PR TITLE
Document optional companion skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ conventions and guardrails on top.
 
 Superpowers is declared as a dependency and installed automatically from the same marketplace.
 
+## Optional companions
+
+`plus-ultra` stays focused on spec-driven development. For day-to-day projects, it pairs well with
+generic skills and MCPs that are intentionally not bundled as dependencies:
+
+- **`frontend-design`** — use for visual direction, layout, typography, and UI polish when a project
+  has a user-facing surface.
+- **`shadcn` / shadcn MCP** — use for shadcn/ui component discovery, docs, examples, and registry
+  operations.
+- **`gh-cli`** — use with the `gh` CLI for issues, pull requests, Actions, releases, and repo
+  operations.
+- **Neon skills / MCPs** — use when a project adopts the default Neon Postgres path from
+  `plus-ultra:tech-stack`.
+
+`plus-ultra:new-project` treats these as companion capabilities: use them when available, note when
+they are missing, and continue with plain CLI/docs when the project can still be scaffolded safely.
+
 ## What it adds
 
 - **Skills (portable, `plus-ultra:*` when installed as a plugin):**

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -12,6 +12,13 @@ haven't stated one — this skill fills silence, it doesn't override stated pref
 
 - Confirm project name and whether they want the full **monorepo** (default) or a **single package**
   (throwaway / single-surface). Everything below assumes the monorepo.
+- Check companion capabilities before using stack-specific workflows. Prefer:
+  - `frontend-design` for the web app's visual direction.
+  - `shadcn` or a shadcn MCP for component docs, registry lookup, and component installation.
+  - `gh-cli` with the `gh` CLI for GitHub setup and PR/release workflows.
+  - Neon skills or MCPs for Neon project setup, `DATABASE_URL`, branching, and connection guidance.
+  If a companion is unavailable, do not block scaffolding; say what is missing and fall back to
+  official docs or plain CLI commands.
 - Fetch current setup commands/versions via Context7 before running init commands — don't rely on
   memorized CLI flags for Vite, Hono, Drizzle, Biome, etc.
 
@@ -42,13 +49,18 @@ haven't stated one — this skill fills silence, it doesn't override stated pref
 4. **`apps/api`** — Hono app; validate request bodies with the shared zod schemas; **export the app
    type** for RPC. Drizzle schema + `@neondatabase/serverless` connection.
 5. **`apps/web`** — Vite + React + React Router; Tailwind + shadcn/ui; typed API calls via Hono's
-   `hc<AppType>` client. Apply the `frontend-design` skill for the visual layer.
+   `hc<AppType>` client. Apply `frontend-design` for the visual layer when available. Use shadcn
+   companion tooling for docs/examples/registry operations when available; otherwise use the shadcn
+   CLI and official docs directly.
 6. **Biome** — `biome.json` at root; wire the plus-ultra `auto-format` hook's tool (it runs
    `biome check --write` on edited files).
 7. **CI** — copy [`assets/ci.yml`](./assets/ci.yml) to `.github/workflows/ci.yml` (install → Biome
    ci → typecheck → test).
 8. **Repo conventions** — create `specs/` and `docs/` per `plus-ultra:spec-conventions`; add a
    `.gitignore` covering `node_modules`, `dist`, `.env*` (keep `.env.example`).
+9. **Agent setup note** — if the repo will be used by coding agents, add a short `AGENTS.md` or
+   `docs/agent-setup.md` that names the recommended optional companions (`frontend-design`,
+   `shadcn`, `gh-cli`, Neon skills/MCPs) without requiring them for normal development.
 
 ## After scaffolding
 

--- a/skills/tech-stack/SKILL.md
+++ b/skills/tech-stack/SKILL.md
@@ -55,6 +55,19 @@ move it to `packages/shared`.
 - **Drizzle + Neon** — Drizzle schema lives in `apps/api`; use `@neondatabase/serverless` for the
   connection so it works on serverless/edge runtimes.
 
+## Companion capabilities
+
+These are recommended helpers, not plus-ultra dependencies. Use them when available; if they are
+missing, continue with official docs and CLI commands.
+
+- **`frontend-design`** — apply when creating or reshaping the web app's visual layer.
+- **`shadcn` / shadcn MCP** — use for component docs, registry lookup, examples, and safe component
+  installation.
+- **`gh-cli`** — use with the `gh` CLI for GitHub issues, PRs, Actions, releases, and repository
+  operations.
+- **Neon skills / MCPs** — use for Neon project setup, database URLs, branching, and connection
+  guidance.
+
 ## Fit with the rest of plus-ultra
 
 - `plus-ultra:new-project` scaffolds this layout.


### PR DESCRIPTION
Documents optional companion skills and MCPs that pair with plus-ultra without making them dependencies.

Updates tech-stack and new-project so agents check for frontend-design, shadcn, gh-cli, and Neon helpers when available, then fall back to CLI/docs if missing.

Also notes that generated repos can include an AGENTS.md or docs/agent-setup.md naming recommended companions.

Verification: git diff --check; claude plugin validate .; claude plugin validate .claude-plugin/plugin.json; claude plugin validate .claude-plugin/marketplace.json --strict.