### PR TITLE
Add engineering principles guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,17 @@ they are missing, and continue with plain CLI/docs when the project can still be
 
 - **Skills (portable, `plus-ultra:*` when installed as a plugin):**
   - *spec-conventions* — `specs/NNN-slug.md` numbering + a spec template (Problem, Goals/Non-goals,
-    Acceptance criteria, Interface contracts, Data model, Test plan, Risks) with a `status:` lifecycle
-    (draft → approved → in-progress → done). Plus `docs/` layout and an ADR template.
+    Acceptance criteria, Interface contracts, Architecture boundaries, Functional core, Data model,
+    Test plan, Risks) with a `status:` lifecycle (draft → approved → in-progress → done). Plus
+    `docs/` layout and an ADR template.
   - *spec* — portable equivalent of `/plus-ultra:spec`: list specs, create the next-numbered spec,
     or flip a spec's status.
   - *tech-stack* — the default stack: a TypeScript-everywhere **pnpm-workspaces monorepo** —
     React + Vite (web), Hono (api), shared zod/types, Drizzle + Neon, vitest, Biome. Defaults, with
     a stated escape hatch per row.
+  - *engineering-principles* — default guidance for hexagonal architecture and functional programming
+    where applicable: domain/application boundaries, ports/adapters, pure functions,
+    immutable data, explicit error values, and side-effect isolation.
   - *conventional-commits* — the commit message format (enforced by the commit-msg-lint hook).
   - *pull-request-descriptions* — drafts reviewer-focused PR bodies that connect context, summary,
     testing, risks, and review guidance.
@@ -107,8 +111,9 @@ Hooks are dependency-free Node ESM scripts under `hooks/`. They read the hook JS
 .cursor-plugin/plugin.json       Cursor manifest (skills only)
 .agents/plugins/marketplace.json open-agents marketplace entry
 skills/                          portable skills (spec-conventions, spec, tech-stack,
-                                 conventional-commits, pull-request-descriptions,
-                                 new-project, repo-explorer, code-reviewer, dep-auditor) —
+                                 engineering-principles, conventional-commits,
+                                 pull-request-descriptions, new-project, repo-explorer,
+                                 code-reviewer, dep-auditor) —
                                  shared by all agents
 commands/spec.md                 /plus-ultra:spec lifecycle command — Claude only
 agents/                          repo-explorer, code-reviewer, dep-auditor — Claude only

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -10,17 +10,31 @@ Review the current branch for a spec-driven Node/TypeScript project.
 ## Process
 
 1. Identify the in-progress spec by scanning `specs/*.md` for `status: in-progress`.
-2. Read that spec's `Acceptance criteria`, `Interface contracts`, and `Test plan` sections.
+2. Read that spec's `Acceptance criteria`, `Interface contracts`, `Architecture boundaries`,
+   `Functional core`, and `Test plan` sections.
 3. Get the current branch diff with `git diff --merge-base main`.
 4. If that fails or is empty when changes are expected, fall back to `git diff origin/main...` or `git diff main...`.
 5. Read changed files for context where the diff alone is unclear.
 6. Check each acceptance criterion: met, partially met, or missing.
 7. Look for correctness risks: unhandled errors, edge cases named in `Risks`, missing tests from the `Test plan`, and interface mismatches against declared contracts.
+8. Check `plus-ultra:engineering-principles` where applicable:
+   - The dependency rule points inward. Domain/application code should not import Hono, Drizzle,
+     React, environment helpers, filesystem APIs, network clients, or concrete adapters.
+   - Business rules should live in domain/application code, not route handlers, React components,
+     SQL builders, CLI glue, or SDK wrappers.
+   - Side effects should be isolated behind ports and implemented in adapters.
+   - Expected domain/application failures should use explicit result values or discriminated unions
+     instead of framework-shaped exceptions.
+   - Unit tests should cover the functional core without real HTTP, database, filesystem, or network
+     dependencies.
 
 ## Output
 
 - **Acceptance criteria:** checklist with each item marked met, partial, or missing, with a one-line reason and `path:line`.
 - **Correctness findings:** most severe first, each with a concrete failure scenario.
+- **Architecture findings:** dependency direction, ports/adapters, functional core, and side-effect
+  isolation issues. Only report issues that affect the changed code and are not explicitly justified
+  by the spec.
 - **Verdict:** ready or not ready to mark done, with blocking items.
 
 Do not modify files. Be specific and cite `path:line`. Only report issues you can substantiate from the diff or code.

--- a/skills/engineering-principles/SKILL.md
+++ b/skills/engineering-principles/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: engineering-principles
+description: Use when designing, scaffolding, implementing, or reviewing TypeScript application code where hexagonal architecture, functional programming, domain boundaries, ports, adapters, or side-effect isolation are relevant.
+---
+
+# plus-ultra engineering principles
+
+Use hexagonal architecture and functional programming when they make the code easier to test,
+change, and reason about. These are defaults, not ceremony: keep the boundary when the code has
+business rules or external integrations; keep tiny scripts and one-off glue simple.
+
+## Hexagonal Architecture
+
+Apply the dependency rule: source code points inward.
+
+```
+domain <- application <- adapters/http/db/ui/cli
+```
+
+- `domain` contains business types, pure rules, and invariants. It must not import frameworks,
+  database clients, HTTP libraries, environment helpers, filesystem APIs, or UI code.
+- `application` contains use cases. It coordinates domain behavior through explicit inputs and
+  output ports. It may depend on `domain` and `ports`, not concrete adapters.
+- `ports` define interfaces for external capabilities: repositories, clocks, id generators,
+  mailers, queues, gateways, and telemetry.
+- `adapters` implement ports with real tools such as Drizzle, Neon, Hono, browser APIs, or third
+  party SDKs.
+- `http`, `ui`, and `cli` translate transport details into application calls. Keep validation,
+  auth extraction, status codes, and serialization there; keep business decisions out.
+
+## Functional Programming Defaults
+
+- Prefer pure functions for domain logic: explicit arguments in, explicit result out.
+- Keep data immutable by default; return new values instead of mutating caller-owned objects.
+- Model expected failures with typed results or discriminated unions instead of throwing across
+  application boundaries.
+- Inject side-effecting capabilities through ports. Pass clocks, IDs, persistence, and network
+  clients in from the outside.
+- Compose small functions before adding classes. Use classes only when they represent a stateful
+  adapter or a framework requires them.
+
+## TypeScript Shape
+
+For the default API package, start with this layout:
+
+```
+src/
+  domain/
+  application/
+  ports/
+  adapters/
+  http/
+```
+
+Use cases should be easy to test without Hono, Drizzle, network calls, or a real database. A good
+test can call the application function with in-memory port implementations and assert the returned
+result plus port calls.
+
+## Review Checklist
+
+- Domain/application code has no outward imports to frameworks or infrastructure.
+- Business rules are not hidden in route handlers, React components, SQL builders, or SDK wrappers.
+- Side effects are isolated behind ports and called from the application layer.
+- Tests cover the functional core without real HTTP, database, filesystem, or network dependencies.
+- Any deviation is intentional and documented in the spec or PR.

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -13,6 +13,8 @@ haven't stated one — this skill fills silence, it doesn't override stated pref
 - Confirm project name and whether they want the full **monorepo** (default) or a **single package**
   (throwaway / single-surface). Everything below assumes the monorepo.
 - Check companion capabilities before using stack-specific workflows. Prefer:
+  - `plus-ultra:engineering-principles` for hexagonal architecture and functional programming
+    defaults when the project has business rules or external integrations.
   - `frontend-design` for the web app's visual direction.
   - `shadcn` or a shadcn MCP for component docs, registry lookup, and component installation.
   - `gh-cli` with the `gh` CLI for GitHub setup and PR/release workflows.
@@ -33,7 +35,7 @@ haven't stated one — this skill fills silence, it doesn't override stated pref
 ├── .github/workflows/ci.yml # from this skill's assets/ci.yml
 ├── apps/
 │   ├── web/                 # React + Vite + React Router + Tailwind + shadcn/ui
-│   └── api/                 # Hono server + Drizzle (Neon Postgres)
+│   └── api/                 # Hono server + hexagonal core + Drizzle (Neon Postgres)
 └── packages/
     └── shared/              # zod schemas + types imported by BOTH apps
 ```
@@ -46,8 +48,15 @@ haven't stated one — this skill fills silence, it doesn't override stated pref
 2. **`tsconfig.base.json`** — `strict: true`, `moduleResolution: bundler`, `noUncheckedIndexedAccess`.
    Each workspace extends it.
 3. **`packages/shared`** — export zod schemas + inferred types. This is the front↔back contract.
-4. **`apps/api`** — Hono app; validate request bodies with the shared zod schemas; **export the app
-   type** for RPC. Drizzle schema + `@neondatabase/serverless` connection.
+4. **`apps/api`** — Hono app around a hexagonal, functional core. Use:
+   - `src/domain` for pure business types, rules, and invariants.
+   - `src/application` for a pure use case layer that coordinates domain logic through ports.
+   - `src/ports` for repository, clock, ID, queue, gateway, and telemetry interfaces.
+   - `src/adapters` for Drizzle, Neon, SDK, filesystem, and network implementations.
+   - `src/http` for Hono routes, validation, auth extraction, status codes, and serialization.
+   Validate request bodies with the shared zod schemas; **export the app type** for RPC. Drizzle
+   schema + `@neondatabase/serverless` connection stay in adapters. Keep domain/application imports
+   inward: no Hono, Drizzle, React, environment helpers, filesystem APIs, or network clients.
 5. **`apps/web`** — Vite + React + React Router; Tailwind + shadcn/ui; typed API calls via Hono's
    `hc<AppType>` client. Apply `frontend-design` for the visual layer when available. Use shadcn
    companion tooling for docs/examples/registry operations when available; otherwise use the shadcn
@@ -61,6 +70,23 @@ haven't stated one — this skill fills silence, it doesn't override stated pref
 9. **Agent setup note** — if the repo will be used by coding agents, add a short `AGENTS.md` or
    `docs/agent-setup.md` that names the recommended optional companions (`frontend-design`,
    `shadcn`, `gh-cli`, Neon skills/MCPs) without requiring them for normal development.
+
+## API shape
+
+Use this structure for non-trivial APIs:
+
+```
+apps/api/src/
+  domain/
+  application/
+  ports/
+  adapters/
+  http/
+```
+
+The initial example should include one pure use case that accepts explicit input plus injected
+ports and returns a typed result. Route handlers should translate HTTP details into that use case.
+Repository adapters should implement ports and be replaceable by in-memory fakes in unit tests.
 
 ## After scaffolding
 

--- a/skills/spec-conventions/SKILL.md
+++ b/skills/spec-conventions/SKILL.md
@@ -38,10 +38,14 @@ New specs start from [`template.md`](./template.md). Required sections:
 3. **Acceptance criteria** — checklist the implementation must satisfy. The `plus-ultra:code-reviewer`
    subagent diffs the branch against these.
 4. **Interface contracts** — public APIs, function signatures, CLI flags, HTTP routes, events.
-5. **Data model** — schemas, types, migrations, persisted shapes.
-6. **Test plan** — what to test and at what level (unit/integration/e2e). Tests must pass before
+5. **Architecture boundaries** — domain/application modules, ports, adapters, and dependency
+   direction for changes where hexagonal architecture is applicable.
+6. **Functional core** — pure functions, immutable data, explicit result/error types, injected
+   dependencies, side-effect boundaries, and any justified deviation.
+7. **Data model** — schemas, types, migrations, persisted shapes.
+8. **Test plan** — what to test and at what level (unit/integration/e2e). Tests must pass before
    commit (enforced by the `commit-gate` hook).
-7. **Risks** — what could go wrong, edge cases, rollback story.
+9. **Risks** — what could go wrong, edge cases, rollback story.
 
 ## Docs live in `docs/`
 

--- a/skills/spec-conventions/template.md
+++ b/skills/spec-conventions/template.md
@@ -23,6 +23,14 @@ created: <YYYY-MM-DD>
 ## Interface contracts
 <Public APIs, function signatures, CLI flags, HTTP routes, events. Include types.>
 
+## Architecture boundaries
+<Hexagonal boundaries for this change: domain/application modules, ports, adapters, and dependency
+direction. Note where framework, database, network, filesystem, or UI details are isolated.>
+
+## Functional core
+<Pure functions, immutable data, explicit result/error types, injected dependencies, and side effects
+that should stay behind ports. Explain any deliberate deviation.>
+
 ## Data model
 <Schemas, types, migrations, persisted shapes.>
 

--- a/skills/tech-stack/SKILL.md
+++ b/skills/tech-stack/SKILL.md
@@ -6,7 +6,8 @@ description: The default technology stack for new projects in this harness — a
 # plus-ultra default tech stack
 
 Opinionated defaults so a new project starts without re-litigating tooling. **TypeScript on both
-ends, React on the front, Hono on the back, one monorepo, types shared across the boundary.**
+ends, React on the front, Hono on the back, one monorepo, types shared across the boundary, and
+hexagonal architecture around a functional core where application complexity justifies it.**
 
 These are defaults, not laws. Each row says when to deviate. If the user names a different tool,
 follow the user — this skill only fills silence.
@@ -41,6 +42,21 @@ apps/api           Hono server
 packages/shared    zod schemas + types imported by BOTH apps
 ```
 
+In `apps/api`, use `plus-ultra:engineering-principles` when business logic or infrastructure
+integration is involved. Default to a functional core with hexagonal boundaries:
+
+```
+apps/api/src/domain       pure business types, rules, invariants
+apps/api/src/application  use cases that coordinate domain logic through ports
+apps/api/src/ports        interfaces for persistence, clocks, IDs, queues, gateways
+apps/api/src/adapters     concrete Drizzle/Neon/SDK implementations of ports
+apps/api/src/http         Hono routes, validation, auth extraction, serialization
+```
+
+The dependency rule is inward only: domain/application code must not import Hono, Drizzle, React,
+environment helpers, filesystem APIs, or network clients. Expected failures should be modeled with
+typed results or discriminated unions. Side effects belong behind ports and adapters.
+
 The point of TypeScript-on-both-ends is the shared boundary: **define a shape once as a zod schema
 in `packages/shared`**, and both the API (validate input) and the web app (typed fetch via Hono RPC)
 consume it. No duplicated types, no drift. If you find yourself writing the same interface twice,
@@ -54,6 +70,8 @@ move it to `packages/shared`.
   Hono validates with it server-side; the web app infers types from it client-side.
 - **Drizzle + Neon** — Drizzle schema lives in `apps/api`; use `@neondatabase/serverless` for the
   connection so it works on serverless/edge runtimes.
+- **Functional core** — application use cases accept data plus ports and return explicit results.
+  Hono routes and Drizzle repositories adapt external details to that core.
 
 ## Companion capabilities
 
@@ -71,6 +89,8 @@ missing, continue with official docs and CLI commands.
 ## Fit with the rest of plus-ultra
 
 - `plus-ultra:new-project` scaffolds this layout.
+- `plus-ultra:engineering-principles` defines the architecture and functional programming defaults
+  for non-trivial application code.
 - The `auto-format` hook runs **Biome** on edited files — matches this stack's lint/format pick.
 - The `commit-gate` hook requires a passing **vitest** run (and a `tsc` typecheck in TS projects)
   before commit.

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -54,3 +54,59 @@ test("pull-request-descriptions skill is packaged and discoverable", () => {
   const readme = readRelative("README.md");
   assert.match(readme, /pull-request-descriptions/);
 });
+
+test("engineering-principles skill is packaged and connected to project workflow", () => {
+  const skillPath = "skills/engineering-principles/SKILL.md";
+  assert.ok(existsSync(join(repoRoot, skillPath)), `${skillPath} exists`);
+
+  const skill = readRelative(skillPath);
+  const frontmatter = parseFrontmatter(skill);
+
+  assert.equal(frontmatter.name, "engineering-principles");
+  assert.match(frontmatter.description, /Use when/i);
+  assert.match(frontmatter.description, /hexagonal|functional/i);
+
+  for (const expectedTerm of [
+    "domain",
+    "application",
+    "ports",
+    "adapters",
+    "pure functions",
+    "dependency rule",
+  ]) {
+    assert.match(skill, new RegExp(expectedTerm, "i"));
+  }
+
+  const readme = readRelative("README.md");
+  assert.match(readme, /engineering-principles/);
+  assert.match(readme, /hexagonal architecture/i);
+  assert.match(readme, /functional programming/i);
+});
+
+test("project scaffolding and review guidance enforce architecture and FP conventions", () => {
+  const techStack = readRelative("skills/tech-stack/SKILL.md");
+  assert.match(techStack, /engineering-principles/);
+  assert.match(techStack, /hexagonal/i);
+  assert.match(techStack, /functional core/i);
+
+  const newProject = readRelative("skills/new-project/SKILL.md");
+  for (const expectedPath of [
+    "src/domain",
+    "src/application",
+    "src/ports",
+    "src/adapters",
+    "src/http",
+  ]) {
+    assert.match(newProject, new RegExp(expectedPath.replace("/", "\\/")));
+  }
+  assert.match(newProject, /pure use case/i);
+
+  const specTemplate = readRelative("skills/spec-conventions/template.md");
+  assert.match(specTemplate, /Architecture boundaries/i);
+  assert.match(specTemplate, /Functional core/i);
+
+  const codeReviewer = readRelative("skills/code-reviewer/SKILL.md");
+  assert.match(codeReviewer, /dependency rule/i);
+  assert.match(codeReviewer, /side effects/i);
+  assert.match(codeReviewer, /adapters/i);
+});


### PR DESCRIPTION
## Summary
- Adds a portable engineering-principles skill for hexagonal architecture, functional programming defaults, ports/adapters, and side-effect isolation.
- Wires those conventions into tech-stack, new-project scaffolding, spec templates, code review guidance, and README discoverability.

## Testing
- node --test tests/*.test.mjs
- git diff --check

## Risks
- None known; this is guidance and test coverage only, with no runtime hook behavior changed.