### PR TITLE
feat(skills): add optional quality companions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,28 @@ generic skills and MCPs that are intentionally not bundled as dependencies:
   operations.
 - **Neon skills / MCPs** — use when a project adopts the default Neon Postgres path from
   `plus-ultra:tech-stack`.
+- **`vercel-react-best-practices`** — use for React and Next.js implementation or review where
+  rendering, data fetching, bundle size, or runtime performance matters.
+- **`vercel-composition-patterns`** — use when designing reusable React component APIs or refactoring
+  components overloaded with boolean props.
+- **`vitest`** — use for Vitest-specific test design, mocking, configuration, debugging, and suite
+  reliability.
+- **`playwright-best-practices`** — use when a project has selected Playwright for browser E2E
+  coverage and needs reliable locators, isolation, fixtures, or CI guidance.
 
 `plus-ultra:new-project` treats these as companion capabilities: use them when available, note when
 they are missing, and continue with plain CLI/docs when the project can still be scaffolded safely.
+They do not replace Superpowers' workflow or `plus-ultra`'s architecture defaults, and they are not
+installed automatically.
+
+Install any of the quality companions you want with the skills CLI:
+
+```sh
+npx skills add vercel-labs/agent-skills@vercel-react-best-practices
+npx skills add vercel-labs/agent-skills@vercel-composition-patterns
+npx skills add pproenca/dot-skills@vitest
+npx skills add currents-dev/playwright-best-practices-skill@playwright-best-practices
+```
 
 ## What it adds
 

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -17,10 +17,17 @@ haven't stated one — this skill fills silence, it doesn't override stated pref
     defaults when the project has business rules or external integrations.
   - `frontend-design` for the web app's visual direction.
   - `shadcn` or a shadcn MCP for component docs, registry lookup, and component installation.
+  - `vercel-react-best-practices` for React rendering, data-fetching, bundle, and runtime
+    performance guidance.
+  - `vercel-composition-patterns` for reusable React component API design.
+  - `vitest` for Vitest-specific test design, mocking, configuration, debugging, and reliability.
+  - `playwright-best-practices` only if the user selects Playwright or the project already uses it
+    for browser E2E tests.
   - `gh-cli` with the `gh` CLI for GitHub setup and PR/release workflows.
   - Neon skills or MCPs for Neon project setup, `DATABASE_URL`, branching, and connection guidance.
   If a companion is unavailable, do not block scaffolding; say what is missing and fall back to
-  official docs or plain CLI commands.
+  official docs or plain CLI commands. Companions are optional advisors: do not install them or add
+  their associated libraries unless the user asks.
 - Fetch current setup commands/versions via Context7 before running init commands — don't rely on
   memorized CLI flags for Vite, Hono, Drizzle, Biome, etc.
 
@@ -60,16 +67,24 @@ haven't stated one — this skill fills silence, it doesn't override stated pref
 5. **`apps/web`** — Vite + React + React Router; Tailwind + shadcn/ui; typed API calls via Hono's
    `hc<AppType>` client. Apply `frontend-design` for the visual layer when available. Use shadcn
    companion tooling for docs/examples/registry operations when available; otherwise use the shadcn
-   CLI and official docs directly.
+   CLI and official docs directly. When available, use `vercel-react-best-practices` for React
+   performance-sensitive implementation and review, and `vercel-composition-patterns` when shaping
+   reusable component APIs.
 6. **Biome** — `biome.json` at root; wire the plus-ultra `auto-format` hook's tool (it runs
    `biome check --write` on edited files).
-7. **CI** — copy [`assets/ci.yml`](./assets/ci.yml) to `.github/workflows/ci.yml` (install → Biome
-   ci → typecheck → test).
-8. **Repo conventions** — create `specs/` and `docs/` per `plus-ultra:spec-conventions`; add a
+7. **Testing** — configure Vitest for unit and integration tests; use the optional `vitest`
+   companion when present for framework-specific setup, mocking, debugging, and reliability.
+   Add Playwright browser E2E only when the user requests it; if selected and
+   `playwright-best-practices` is available, use it for locators, isolation, fixtures, and CI.
+8. **CI** — copy [`assets/ci.yml`](./assets/ci.yml) to `.github/workflows/ci.yml` (install → Biome
+   ci → typecheck → test). Extend it with browser E2E only if Playwright was selected.
+9. **Repo conventions** — create `specs/` and `docs/` per `plus-ultra:spec-conventions`; add a
    `.gitignore` covering `node_modules`, `dist`, `.env*` (keep `.env.example`).
-9. **Agent setup note** — if the repo will be used by coding agents, add a short `AGENTS.md` or
+10. **Agent setup note** — if the repo will be used by coding agents, add a short `AGENTS.md` or
    `docs/agent-setup.md` that names the recommended optional companions (`frontend-design`,
-   `shadcn`, `gh-cli`, Neon skills/MCPs) without requiring them for normal development.
+   `shadcn`, `vercel-react-best-practices`, `vercel-composition-patterns`, `vitest`,
+   `playwright-best-practices`, `gh-cli`, Neon skills/MCPs) without requiring them for normal
+   development.
 
 ## API shape
 

--- a/skills/tech-stack/SKILL.md
+++ b/skills/tech-stack/SKILL.md
@@ -81,10 +81,22 @@ missing, continue with official docs and CLI commands.
 - **`frontend-design`** — apply when creating or reshaping the web app's visual layer.
 - **`shadcn` / shadcn MCP** — use for component docs, registry lookup, examples, and safe component
   installation.
+- **`vercel-react-best-practices`** — apply to React implementation and review when rendering,
+  data fetching, bundle size, or runtime performance matters.
+- **`vercel-composition-patterns`** — apply when designing reusable React component APIs or
+  refactoring components overloaded with boolean props.
+- **`vitest`** — apply for Vitest-specific test design, mocking, configuration, debugging, and
+  suite reliability. Superpowers still owns the test-first workflow.
+- **`playwright-best-practices`** — apply only when the user selects Playwright or the project
+  already contains Playwright browser E2E tests. It does not make Playwright a stack dependency.
 - **`gh-cli`** — use with the `gh` CLI for GitHub issues, PRs, Actions, releases, and repository
   operations.
 - **Neon skills / MCPs** — use for Neon project setup, database URLs, branching, and connection
   guidance.
+
+These companions are technology-specific advisors. They do not replace Superpowers' methodology,
+`plus-ultra:engineering-principles`, or the user's explicit choices, and their absence must not
+block normal work.
 
 ## Fit with the rest of plus-ultra
 

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -9,6 +9,16 @@ function readRelative(path) {
   return readFileSync(join(repoRoot, path), "utf8");
 }
 
+function markdownSection(markdown, heading) {
+  const marker = `## ${heading}\n`;
+  const start = markdown.indexOf(marker);
+  assert.notEqual(start, -1, `${heading} section exists`);
+
+  const content = markdown.slice(start + marker.length);
+  const nextHeading = content.search(/^## /m);
+  return nextHeading === -1 ? content : content.slice(0, nextHeading);
+}
+
 function parseFrontmatter(markdown) {
   const match = markdown.match(/^---\n([\s\S]*?)\n---\n/);
   assert.ok(match, "skill has YAML frontmatter");
@@ -109,4 +119,73 @@ test("project scaffolding and review guidance enforce architecture and FP conven
   assert.match(codeReviewer, /dependency rule/i);
   assert.match(codeReviewer, /side effects/i);
   assert.match(codeReviewer, /adapters/i);
+});
+
+test("quality companions are documented and remain optional and technology-scoped", () => {
+  const readme = readRelative("README.md");
+  const techStack = readRelative("skills/tech-stack/SKILL.md");
+  const newProject = readRelative("skills/new-project/SKILL.md");
+  const readmeCompanions = markdownSection(readme, "Optional companions");
+  const techCompanions = markdownSection(techStack, "Companion capabilities");
+  const beforeScaffolding = markdownSection(newProject, "Before scaffolding");
+  const scaffoldSteps = markdownSection(newProject, "Steps");
+
+  const companions = [
+    "vercel-react-best-practices",
+    "vercel-composition-patterns",
+    "vitest",
+    "playwright-best-practices",
+  ];
+
+  for (const companion of companions) {
+    assert.match(readmeCompanions, new RegExp(companion));
+    assert.match(techCompanions, new RegExp(companion));
+    assert.match(beforeScaffolding, new RegExp(companion));
+  }
+
+  const installCommands = [
+    "npx skills add vercel-labs/agent-skills@vercel-react-best-practices",
+    "npx skills add vercel-labs/agent-skills@vercel-composition-patterns",
+    "npx skills add pproenca/dot-skills@vitest",
+    "npx skills add currents-dev/playwright-best-practices-skill@playwright-best-practices",
+  ];
+  const readmeLines = readmeCompanions.split("\n");
+  for (const command of installCommands) {
+    assert.ok(readmeLines.includes(command), `${command} is an exact command line`);
+  }
+
+  assert.match(readmeCompanions, /not bundled as dependencies/i);
+  assert.match(readmeCompanions, /not\s+installed automatically/i);
+  assert.match(techCompanions, /technology-specific advisors/i);
+  assert.match(techCompanions, /do not replace Superpowers' methodology/i);
+  assert.match(techCompanions, /does not make Playwright a stack dependency/i);
+  assert.match(beforeScaffolding, /Companions are optional advisors: do not install them/i);
+
+  assert.match(
+    beforeScaffolding,
+    /`vercel-react-best-practices` for React rendering,[\s\S]*performance guidance\./
+  );
+  assert.match(
+    beforeScaffolding,
+    /`vercel-composition-patterns` for reusable React component API design\./
+  );
+  assert.match(
+    beforeScaffolding,
+    /`vitest` for Vitest-specific test design,[\s\S]*reliability\./
+  );
+  assert.match(
+    beforeScaffolding,
+    /`playwright-best-practices` only if the user selects Playwright[\s\S]*browser E2E tests\./
+  );
+  assert.match(
+    scaffoldSteps,
+    /use `vercel-react-best-practices` for React[\s\S]*`vercel-composition-patterns`[\s\S]*reusable component APIs\./
+  );
+  assert.match(
+    scaffoldSteps,
+    /Add Playwright browser E2E only when the user requests it[\s\S]*`playwright-best-practices` is available/
+  );
+
+  const claudeManifest = JSON.parse(readRelative(".claude-plugin/plugin.json"));
+  assert.deepEqual(claudeManifest.dependencies, ["superpowers"]);
 });


### PR DESCRIPTION
## Context
The harness lacked focused guidance for React performance and composition, Vitest reliability, and browser E2E while needing to preserve Superpowers as the methodology owner.

## Summary
This PR documents four independently installed companion skills, routes them through `tech-stack` and `new-project`, keeps Playwright conditional, and adds regression coverage for discoverability, ownership, exact install commands, and optionality.

## Testing
- `node --test tests/*.test.mjs` — 9/9 passing
- `git diff --check`
- `claude plugin validate --strict .`
- `claude plugin validate --strict .claude-plugin/plugin.json`

## Risks
None known; the companions remain optional and add no plugin dependencies or automatic installation behavior.

## Review Guidance
Please focus on the ownership boundaries and conditional routing enforced by `tests/skills.test.mjs`.
