### PR TITLE
feat(skills): add human-first PR description guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.context/
+/.codex/
 /docs/superpowers/

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ npx skills add currents-dev/playwright-best-practices-skill@playwright-best-prac
     where applicable: domain/application boundaries, ports/adapters, pure functions,
     immutable data, explicit error values, and side-effect isolation.
   - *conventional-commits* — the commit message format (enforced by the commit-msg-lint hook).
-  - *pull-request-descriptions* — drafts reviewer-focused PR bodies that connect context, summary,
-    testing, risks, and review guidance.
+  - *pull-request-descriptions* — drafts reviewer-focused PR bodies with a human-first overview and
+    conditional Mermaid diagrams, then connects context, summary, testing, risks, and review guidance.
   - *new-project* — scaffolds the tech-stack monorepo + CI.
   - *repo-explorer*, *code-reviewer*, *dep-auditor* — portable skill equivalents of the Claude
     subagents.

--- a/skills/pull-request-descriptions/SKILL.md
+++ b/skills/pull-request-descriptions/SKILL.md
@@ -7,8 +7,9 @@ description: "Use when drafting, revising, or reviewing pull request description
 
 ## Overview
 
-Write PR descriptions as a reviewer handoff, not a changelog. A good body explains why the change
-exists, what behavior changed, how it was verified, and where reviewers should focus.
+Write PR descriptions as a reviewer handoff, not a changelog. Lead with a concise, human-first
+overview, then explain why the change exists, what behavior changed, how it was verified, and
+where reviewers should focus.
 
 ## Workflow
 
@@ -26,6 +27,12 @@ exists, what behavior changed, how it was verified, and where reviewers should f
 Use this shape unless the repository has its own required PR template:
 
 ```markdown
+## At a glance
+[At most three sentences: the problem, observable outcome, and affected audience.]
+
+## Diagram
+[Include this entire section only when the diagram rules below require it.]
+
 ## Context
 [Why this change is needed. Link or name the spec/issue when applicable.]
 
@@ -44,6 +51,29 @@ Use this shape unless the repository has its own required PR template:
 ```
 
 ## Section Guidance
+
+**At a glance:** In at most three sentences, state the problem, the observable outcome, and the
+affected audience. Keep implementation and file-level details in later sections.
+
+**Diagram:** Include exactly one compact Mermaid diagram only when the change crosses three or more
+components, services, or modules; changes request, data, control, or dependency flow across
+boundaries; changes lifecycle or state transitions; or has a non-obvious before/after architecture.
+Use `flowchart` for topology or data flow, `sequenceDiagram` for ordered interactions, and
+`stateDiagram-v2` for lifecycle changes. Use human-readable labels and no more than eight nodes or
+participants. Omit the entire Diagram section for localized fixes, straightforward
+documentation/configuration/dependency updates, or visuals that only repeat the overview. Never
+invent relationships or leave placeholder Mermaid. All prose and diagram edges must be supported
+by the diff, issue/spec, or verified behavior.
+
+## Diagram Examples
+
+- **Localized fix:** A one-module validation correction — omit the Diagram section.
+- **Cross-component flow:** An upload request moving through the web app, API, and storage service —
+  use a `flowchart`.
+- **Ordered interaction:** A client request, authorization check, and asynchronous worker handoff —
+  use a `sequenceDiagram`.
+- **Lifecycle change:** A job moving from queued to running, retrying, and complete — use a
+  `stateDiagram-v2`.
 
 **Context:** Explain the problem and intent in one short paragraph. Avoid repeating the branch name
 or commit subject. If this PR implements a spec, mention the spec path and status.
@@ -73,6 +103,10 @@ interfaces, untested paths, copied patterns, generated files, or intentional non
 
 - **Only summarizing commits:** Rewrite around user-facing outcome, architecture boundary, and review
   intent.
+- **Diagram by default:** Omit the Diagram section unless the change meets a stated trigger and the
+  visual adds information beyond the overview.
+- **Unproven visual:** Do not invent diagram edges, components, or transitions that are not supported
+  by the source material.
 - **Overstating validation:** Replace vague claims with exact commands or `Not run`.
 - **Burying risk:** Keep risks visible even when they are acceptable.
 - **Repeating the diff:** Do not list every changed file. Explain why the set of changes hangs

--- a/skills/pull-request-descriptions/agents/openai.yaml
+++ b/skills/pull-request-descriptions/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Pull Request Descriptions"
-  short_description: "Draft reviewer-focused PR descriptions"
+  short_description: "Draft PR descriptions with a human-first overview and conditional Mermaid diagrams"
   default_prompt: "Draft a clear pull request description for the current branch."

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -75,6 +75,75 @@ test("pull-request-descriptions skill is packaged and discoverable", () => {
   assert.match(readme, /pull-request-descriptions/);
 });
 
+test("pull-request-descriptions leads with a human-first overview and conditional Mermaid diagrams", () => {
+  const skill = readRelative("skills/pull-request-descriptions/SKILL.md");
+  const templateStart = skill.indexOf("## Recommended Template");
+  const templateEnd = skill.indexOf("## Section Guidance");
+  assert.notEqual(templateStart, -1, "Recommended Template section exists");
+  assert.notEqual(templateEnd, -1, "Section Guidance section exists");
+  const template = skill.slice(templateStart, templateEnd);
+  const metadata = readRelative("skills/pull-request-descriptions/agents/openai.yaml");
+  const readme = readRelative("README.md");
+
+  const orderedSections = [
+    "At a glance",
+    "Diagram",
+    "Context",
+    "Summary",
+    "Testing",
+    "Risks",
+    "Review Guidance",
+  ];
+  let previousIndex = -1;
+  for (const heading of orderedSections) {
+    const headingIndex = template.indexOf(`## ${heading}`);
+    assert.notEqual(headingIndex, -1, `${heading} is present in the template`);
+    assert.ok(headingIndex > previousIndex, `${heading} follows the previous template section`);
+    previousIndex = headingIndex;
+  }
+
+  const normalized = skill.replace(/\s+/g, " ");
+  assert.match(normalized, /At a glance.*?at most three sentences/i);
+  assert.match(normalized, /problem.*?observable outcome.*?affected audience/i);
+  assert.match(normalized, /exactly one compact Mermaid diagram/i);
+  assert.match(normalized, /three or more components, services, or modules/i);
+  assert.match(normalized, /request, data, control, or dependency flow/i);
+  assert.match(normalized, /lifecycle or state transitions/i);
+  assert.match(normalized, /non-obvious before\/after architecture/i);
+  assert.match(normalized, /localized fixes.*?straightforward documentation\/configuration\/dependency updates/i);
+  assert.match(normalized, /Never invent relationships.*?placeholder Mermaid/i);
+
+  for (const diagram of ["flowchart", "sequenceDiagram", "stateDiagram-v2"]) {
+    assert.match(skill, new RegExp(diagram));
+  }
+  assert.match(normalized, /no more than eight nodes or participants/i);
+
+  for (const expectedSection of [
+    "Context",
+    "Summary",
+    "Testing",
+    "Risks",
+    "Review Guidance",
+  ]) {
+    assert.match(template, new RegExp(`## ${expectedSection}`));
+  }
+
+  assert.match(readme, /human-first overview/i);
+  assert.match(readme, /conditional Mermaid diagrams/i);
+  assert.match(metadata, /human-first overview/i);
+  assert.match(metadata, /conditional Mermaid diagrams/i);
+});
+
+test("pull-request-descriptions demonstrates diagram decisions for common review scenarios", () => {
+  const skill = readRelative("skills/pull-request-descriptions/SKILL.md");
+  const examples = markdownSection(skill, "Diagram Examples").replace(/\s+/g, " ");
+
+  assert.match(examples, /localized fix.*?omit the Diagram section/i);
+  assert.match(examples, /cross-component flow.*?flowchart/i);
+  assert.match(examples, /ordered interaction.*?sequenceDiagram/i);
+  assert.match(examples, /lifecycle change.*?stateDiagram-v2/i);
+});
+
 test("engineering-principles skill is packaged and connected to project workflow", () => {
   const skillPath = "skills/engineering-principles/SKILL.md";
   assert.ok(existsSync(join(repoRoot, skillPath)), `${skillPath} exists`);


### PR DESCRIPTION
## At a glance
PR descriptions now lead with a concise outcome-focused overview and use Mermaid only when a visual clarifies meaningful architecture or flow changes. Reviewers get faster context while localized documentation, configuration, and dependency changes stay diagram-free.

## Context
Implements #10.

## Summary
- Defines the new template order and evidence-based Mermaid decision rules
- Adds scenarios and contract tests for diagram selection
- Ignores transient Codex session state

## Testing
- `node --test tests/*.test.mjs` — 15 passing
- `claude plugin validate .` and `claude plugin validate .claude-plugin/plugin.json`
- Clean Codex marketplace installation

## Risks
- None known

## Review Guidance
- Confirm the diagram triggers remain strict enough to avoid decorative visuals