### PR TITLE
feat(pr-review): add GitHub PR publishing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,17 @@ npx skills add currents-dev/playwright-best-practices-skill@playwright-best-prac
   - *conventional-commits* — the commit message format (enforced by the commit-msg-lint hook).
   - *pull-request-descriptions* — drafts reviewer-focused PR bodies with a human-first overview and
     conditional Mermaid diagrams, then connects context, summary, testing, risks, and review guidance.
+  - *pr-review* — reviews a GitHub pull request against the single in-progress spec, posts
+    deduplicated right-side findings, and maintains a canonical tagged review summary. It uses the
+    current branch’s PR by default; pass a positive PR number to override it. This workflow requires
+    GitHub write access through `gh`.
   - *new-project* — scaffolds the tech-stack monorepo + CI.
   - *repo-explorer*, *code-reviewer*, *dep-auditor* — portable skill equivalents of the Claude
     subagents.
-- **Slash command:** `/plus-ultra:spec` — list specs, create the next-numbered spec, or flip a
-  spec's status. Claude Code only; Codex uses the `plus-ultra:spec` skill instead.
+- **Slash commands:** `/plus-ultra:spec` — list specs, create the next-numbered spec, or flip a
+  spec's status; `/plus-ultra:pr-review [pr-number]` — publish and maintain a spec-driven PR
+  review. Claude Code only; Codex uses the `plus-ultra:spec` and `plus-ultra:pr-review` skills
+  instead.
 - **Guardrail hooks:**
   - *dangerous-command* (PreToolUse / Bash) — blocks `rm -rf` and force-pushes to `main`/`master`.
   - *secret-scan* (PreToolUse / `git commit`) — blocks a commit whose staged diff contains a
@@ -113,7 +119,8 @@ npx skills add currents-dev/playwright-best-practices-skill@playwright-best-prac
   - *session-start* — reports which spec is `in-progress` (and what's approved/draft) so sessions
     resume without re-explaining context.
 - **Subagents:** `repo-explorer` (read-only scan), `code-reviewer` (diff vs the spec's acceptance
-  criteria), `dep-auditor` (vet new npm packages).
+  criteria), `pr-reviewer` (GitHub review publishing and maintenance), `dep-auditor` (vet new npm
+  packages).
 - **GitHub:** no bundled MCP — use the `gh` CLI (with the `gh-cli` skill) from the shell for PRs,
   issues, Actions, and releases.
 
@@ -135,7 +142,7 @@ environment. Cursor ships skills only.
 
 The slash command in `commands/` and Markdown subagents in `agents/` remain Claude Code formats.
 Codex gets equivalent behavior through the portable `spec`, `repo-explorer`, `code-reviewer`, and
-`dep-auditor` skills.
+`pr-review`, and `dep-auditor` skills.
 
 ## Hook scripts
 
@@ -154,9 +161,9 @@ Hooks are dependency-free Node ESM scripts under `hooks/`. They read the hook JS
 skills/                          portable skills (spec-conventions, spec, tech-stack,
                                  engineering-principles, conventional-commits,
                                  pull-request-descriptions, new-project, repo-explorer,
-                                 code-reviewer, dep-auditor) —
+                                 code-reviewer, pr-review, dep-auditor) —
                                  shared by all agents
-commands/spec.md                 /plus-ultra:spec lifecycle command — Claude only
-agents/                          repo-explorer, code-reviewer, dep-auditor — Claude only
+commands/                        /plus-ultra:spec and /plus-ultra:pr-review — Claude only
+agents/                          repo-explorer, code-reviewer, pr-reviewer, dep-auditor — Claude only
 hooks/                           hooks.json, hooks-codex.json + *.mjs
 ```

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -1,0 +1,11 @@
+---
+name: pr-reviewer
+description: Reviews a GitHub pull request against the active spec, publishes tagged findings, and maintains only its own proven-resolved review threads.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are the GitHub PR reviewer. Follow the portable `plus-ultra:pr-review` skill exactly. Validate
+the optional PR number, GitHub authentication/write access, PR metadata, and exactly one in-progress
+spec before any write. Use `gh` only as specified by that skill; preserve other reviewers’ threads
+and report every mutation or skip.

--- a/commands/pr-review.md
+++ b/commands/pr-review.md
@@ -1,0 +1,13 @@
+---
+description: Review a GitHub pull request against the active spec and publish maintained review findings.
+argument-hint: "[pr-number]"
+---
+
+Arguments: `$ARGUMENTS`
+
+Accept no argument, which reviews the PR for the current branch, or one positive integer PR number.
+If the argument is zero, negative, non-numeric, or there is more than one argument, explain the
+valid forms and stop without performing any GitHub write.
+
+Delegate the review to the `plus-ultra:pr-reviewer` agent. It must follow the portable
+`plus-ultra:pr-review` workflow, including its validation and comment-maintenance rules.

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: pr-review
+description: Use when reviewing a GitHub pull request against its in-progress plus-ultra spec and publishing or maintaining actionable review findings.
+---
+
+# plus-ultra PR review
+
+Review one pull request rigorously, publish durable findings, and keep only still-valid findings
+open. This is a writing workflow: it needs authenticated GitHub write access. Use
+`plus-ultra:code-reviewer` instead when a read-only current-branch review is wanted.
+
+## Preconditions and target
+
+1. Accept no argument or one **positive PR number**. With no argument, use the PR for the current
+   branch. Reject zero, negative, non-integer, or extra arguments before any write.
+2. Run `gh auth status`; stop before writes if authentication or GitHub write authorization is not
+   available.
+3. Resolve and validate the PR with `gh pr view <number>` (or `gh pr view` for no argument). Fetch
+   remote metadata including its number, base ref, head ref, head repository, state, URL, and
+   `headRefOid`. Stop before writes if the PR cannot be found, is closed, or is not reviewable.
+4. From the **remote PR head**, list `specs/` and fetch each candidate spec through the GitHub API
+   at `headRefOid`; do not read the local checkout as the source of truth. Require exactly one
+   in-progress spec (`status: in-progress`). Stop before writes if none or more than one exists.
+   Read its acceptance criteria, interface contracts, architecture boundaries, functional core, test
+   plan, and risks.
+
+Do all validation and collection before the first mutation. State every stop or skip and why.
+
+## Gather review evidence
+
+1. Fetch the submitted change with `gh pr diff <pull_number>` and inspect changed files in context.
+   Use the PR base/head range when local context is useful; do not substitute the reviewer’s local
+   branch for the PR head.
+2. Fetch changed-file metadata and patches through the GitHub API as needed. Keep the PR
+   `headRefOid`: it is the commit SHA required for valid inline comments.
+3. Identify the authenticated reviewer (`gh api user`) and enumerate existing review threads with
+   a GraphQL query. **Paginate** until all pages are read; retain thread ID, resolved state, comment
+   author, body, path, line/side, and anchor where available.
+4. Read enough surrounding source, tests, and spec text to substantiate each finding. Review for
+   unmet acceptance criteria, correctness and regression risks, contracts, error handling, tests,
+   and the architecture/functional-core boundaries in `plus-ultra:engineering-principles`.
+
+Only report a defect with a concrete failure scenario and a precise `path:line` when one exists.
+Do not manufacture nits, repeat a finding already addressed by the PR, or treat style preference as
+a defect.
+
+## Findings and markers
+
+Use these exact, stable markers at the beginning of the corresponding Markdown comments:
+
+- Inline: `<!-- plus-ultra:pr-review:inline -->`
+- Summary: `<!-- plus-ultra:pr-review:summary -->`
+
+An inline finding should state severity, the failure scenario, why the selected line causes it, and
+a practical correction. It must be anchored to an added/right-side line in the current PR diff. If
+it cannot be anchored validly, it is **unanchorable** and belongs in the summary instead.
+
+For inline comments, use the REST endpoint `pulls/{pull_number}/comments` with:
+
+- `commit_id` set to the current PR `headRefOid`;
+- the changed-file `path`;
+- `line` pointing to a valid added line; and
+- `side: "RIGHT"`.
+
+Never use a stale SHA, a LEFT-side line, or an approximate line number. If an attempted anchor is
+invalid, do not retry by guessing; record the finding in the summary and report the skipped inline
+mutation.
+
+## Maintain prior review state
+
+Before creating a comment, compare its normalized finding (path, affected behavior, and requested
+fix) with every **equivalent unresolved** tagged thread. Deduplicate equivalent unresolved findings:
+skip a duplicate and report the existing thread instead of creating another one.
+
+For a previously tagged unresolved thread, re-check the current PR head. Resolve it only when a
+fresh review proves the reported problem is fixed. Never resolve a thread merely because code near
+it changed. In addition, only resolve a tagged thread when its review comment was authored by the
+authenticated reviewer; leave other authors’ threads untouched and report that skip. Resolve with
+the GraphQL `resolveReviewThread` mutation and report the thread ID.
+
+## Publish and update the summary
+
+Build one canonical summary containing the summary marker, review scope, spec status, findings by
+severity, unanchorable findings, skipped duplicates, resolutions, and a clear verdict. A no-finding
+summary should say what was reviewed and that no substantiated blocking issues were found.
+
+List PR issue comments through `issues/comments` (paginate if needed) and locate summary marker
+comments created by the authenticated reviewer. Update the most recently updated such summary marker
+comment as the canonical comment; otherwise create it via `issues/comments`. Do not create a new
+summary marker comment on every run. Leave untagged comments and other authors' marker comments
+alone, reporting any existing duplicate marker comments as an ambiguity. Use `gh api` for these
+calls and report the comment ID and whether it was created or updated.
+
+## Final report
+
+Report every mutation and every skip: inline comments created, duplicate inline comments skipped,
+threads resolved or left unresolved (with reason), and the summary created or updated. Include PR
+number and URL, spec path, reviewer identity, findings with `path:line`, and the final verdict. If
+preconditions fail, report the failure and confirm that no GitHub write was attempted.

--- a/skills/pr-review/agents/openai.yaml
+++ b/skills/pr-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Review"
+  short_description: "Publish and maintain a PR review"
+  default_prompt: "Use $pr-review to review this pull request and publish its findings."

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -323,3 +323,59 @@ test("Quick start activates artifact conventions before Superpowers", () => {
     assert.ok(conventionsIndex < superpowersIndex, `${heading} activates conventions first`);
   }
 });
+
+test("pr-review workflow is packaged, safe, and available through Claude", () => {
+  const skillPath = "skills/pr-review/SKILL.md";
+  const commandPath = "commands/pr-review.md";
+  const agentPath = "agents/pr-reviewer.md";
+
+  assert.ok(existsSync(join(repoRoot, skillPath)), `${skillPath} exists`);
+  assert.ok(existsSync(join(repoRoot, commandPath)), `${commandPath} exists`);
+  assert.ok(existsSync(join(repoRoot, agentPath)), `${agentPath} exists`);
+
+  const skill = readRelative(skillPath);
+  const command = readRelative(commandPath);
+  const agent = readRelative(agentPath);
+  const readme = readRelative("README.md");
+  const codeReviewer = readRelative("skills/code-reviewer/SKILL.md");
+  const frontmatter = parseFrontmatter(skill);
+
+  assert.equal(frontmatter.name, "pr-review");
+  assert.match(frontmatter.description, /Use when/i);
+  assert.match(frontmatter.description, /pull request|PR|GitHub/i);
+  assert.match(skill, /no argument/i);
+  assert.match(skill, /positive PR number/i);
+  assert.match(skill, /gh auth status/i);
+  assert.match(skill, /gh pr view/i);
+  assert.match(skill, /gh pr diff/i);
+  assert.match(skill, /headRefOid/i);
+  assert.match(skill, /remote PR head/i);
+  assert.match(skill, /spec.*GitHub API|GitHub API.*spec/i);
+  assert.match(skill, /in-progress spec/i);
+  assert.match(skill, /plus-ultra:pr-review:inline/i);
+  assert.match(skill, /plus-ultra:pr-review:summary/i);
+  assert.match(skill, /pulls\/\{pull_number\}\/comments/i);
+  assert.match(skill, /issues\/comments/i);
+  assert.match(skill, /resolveReviewThread/i);
+  assert.match(skill, /paginate/i);
+  assert.match(skill, /authenticated reviewer/i);
+  assert.match(skill, /summary marker.*authenticated reviewer|authenticated reviewer.*summary marker/i);
+  assert.match(skill, /equivalent unresolved/i);
+  assert.match(skill, /unanchorable/i);
+  assert.match(skill, /Report every mutation/i);
+
+  assert.match(command, /argument-hint: "\[pr-number\]"/);
+  assert.match(command, /positive integer/i);
+  assert.match(command, /plus-ultra:pr-reviewer/);
+  assert.match(agent, /^name: pr-reviewer$/m);
+  assert.match(agent, /^tools: .*Bash/m);
+  assert.match(agent, /plus-ultra:pr-review/);
+
+  assert.match(readme, /plus-ultra:pr-review/);
+  assert.match(readme, /\/plus-ultra:pr-review \[pr-number\]/);
+  assert.match(readme, /GitHub.*write|write.*GitHub/i);
+  assert.match(readme, /pr-reviewer/);
+
+  assert.doesNotMatch(codeReviewer, /\bgh\b/i);
+  assert.match(codeReviewer, /Do not modify files/i);
+});


### PR DESCRIPTION
## At a glance

Adds a maintained GitHub PR-review workflow so contributors can publish spec-driven inline findings and keep resolution status current.

## Context

Closes #11.

## Summary

- Adds the portable `plus-ultra:pr-review` skill plus Claude command and reviewer agent, with a current-branch default and optional PR-number override.
- Documents safe tagged comment/thread lifecycle rules and adds contract coverage.

## Testing

- `node --test tests/hooks.test.mjs tests/skills.test.mjs`
- Skill validation, Claude marketplace validation, and a clean Codex marketplace install.

## Risks

Requires authenticated `gh` credentials with GitHub write access; the workflow exits before writes when its preconditions fail.

## Review Guidance

Review the remote-snapshot, ownership, deduplication, resolution, and summary-update rules in `skills/pr-review/SKILL.md`.