### PR TITLE
feat(issues): add GitHub Issues workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,29 @@ npx skills add pproenca/dot-skills@vitest
 npx skills add currents-dev/playwright-best-practices-skill@playwright-best-practices
 ```
 
+## GitHub Issue workflows
+
+Use GitHub Issues as the source of truth for product work: a **milestone** represents a release or
+roadmap horizon, an **epic** is an issue labelled `type:epic`, and a **story** is its executable
+sub-issue labelled `type:story`. The workflow uses `status:backlog`, `status:ready`,
+`status:in-progress`, and `status:blocked`; closing an issue represents completion. Milestone
+progress aggregates the assigned work, while epic progress comes from its sub-issues.
+
+The portable workflows are:
+
+- **`plus-ultra:issue-management`** — report the hierarchy and progress, or propose milestones,
+  epics, stories, labels, and parent-child links.
+- **`plus-ultra:refine-issues`** — turn a raw person-created issue into a proposed structured brief:
+  `Context`, `Goal`, `Scope`, acceptance criteria, dependencies, and risks.
+- **`plus-ultra:roadmap-planning`** — turn a roadmap brief or issue into a proposed milestone →
+  epic → story tree.
+
+Claude Code also offers `/plus-ultra:issue-management`, `/plus-ultra:refine-issues <issue-number>`,
+and `/plus-ultra:roadmap-planning <brief | issue-number>`. Every GitHub write requires authenticated
+`gh` access with repository write permission, a complete preview of the exact mutations, and an
+explicit confirmation in that execution. These workflows intentionally use neither GitHub Projects
+nor a bundled GitHub MCP.
+
 ## What it adds
 
 - **Skills (portable, `plus-ultra:*` when installed as a plugin):**
@@ -97,13 +120,17 @@ npx skills add currents-dev/playwright-best-practices-skill@playwright-best-prac
     deduplicated right-side findings, and maintains a canonical tagged review summary. It uses the
     current branch’s PR by default; pass a positive PR number to override it. This workflow requires
     GitHub write access through `gh`.
+  - *issue-management*, *refine-issues*, *roadmap-planning* — GitHub Issues workflows for native
+    milestone → epic → story planning, raw issue refinement, and progress reporting. Remote writes
+    are always proposal-first and confirmation-gated.
   - *new-project* — scaffolds the tech-stack monorepo + CI.
   - *repo-explorer*, *code-reviewer*, *dep-auditor* — portable skill equivalents of the Claude
     subagents.
 - **Slash commands:** `/plus-ultra:spec` — list specs, create the next-numbered spec, or flip a
   spec's status; `/plus-ultra:pr-review [pr-number]` — publish and maintain a spec-driven PR
-  review. Claude Code only; Codex uses the `plus-ultra:spec` and `plus-ultra:pr-review` skills
-  instead.
+  review; `/plus-ultra:issue-management`, `/plus-ultra:refine-issues <issue-number>`, and
+  `/plus-ultra:roadmap-planning <brief | issue-number>` — manage GitHub Issue roadmaps. Claude Code
+  only; Codex uses the corresponding portable skills instead.
 - **Guardrail hooks:**
   - *dangerous-command* (PreToolUse / Bash) — blocks `rm -rf` and force-pushes to `main`/`master`.
   - *secret-scan* (PreToolUse / `git commit`) — blocks a commit whose staged diff contains a
@@ -119,8 +146,9 @@ npx skills add currents-dev/playwright-best-practices-skill@playwright-best-prac
   - *session-start* — reports which spec is `in-progress` (and what's approved/draft) so sessions
     resume without re-explaining context.
 - **Subagents:** `repo-explorer` (read-only scan), `code-reviewer` (diff vs the spec's acceptance
-  criteria), `pr-reviewer` (GitHub review publishing and maintenance), `dep-auditor` (vet new npm
-  packages).
+  criteria), `pr-reviewer` (GitHub review publishing and maintenance), `issue-manager`,
+  `issue-refiner`, `roadmap-planner` (confirmation-gated GitHub Issue workflows), and `dep-auditor`
+  (vet new npm packages).
 - **GitHub:** no bundled MCP — use the `gh` CLI (with the `gh-cli` skill) from the shell for PRs,
   issues, Actions, and releases.
 
@@ -142,7 +170,7 @@ environment. Cursor ships skills only.
 
 The slash command in `commands/` and Markdown subagents in `agents/` remain Claude Code formats.
 Codex gets equivalent behavior through the portable `spec`, `repo-explorer`, `code-reviewer`, and
-`pr-review`, and `dep-auditor` skills.
+`pr-review`, `issue-management`, `refine-issues`, `roadmap-planning`, and `dep-auditor` skills.
 
 ## Hook scripts
 
@@ -161,9 +189,11 @@ Hooks are dependency-free Node ESM scripts under `hooks/`. They read the hook JS
 skills/                          portable skills (spec-conventions, spec, tech-stack,
                                  engineering-principles, conventional-commits,
                                  pull-request-descriptions, new-project, repo-explorer,
-                                 code-reviewer, pr-review, dep-auditor) —
+                                 code-reviewer, pr-review, issue-management, refine-issues,
+                                 roadmap-planning, dep-auditor) —
                                  shared by all agents
-commands/                        /plus-ultra:spec and /plus-ultra:pr-review — Claude only
-agents/                          repo-explorer, code-reviewer, pr-reviewer, dep-auditor — Claude only
+commands/                        /plus-ultra:spec, /plus-ultra:pr-review, and Issue workflows — Claude only
+agents/                          repo-explorer, code-reviewer, pr-reviewer, Issue workflow agents,
+                                 dep-auditor — Claude only
 hooks/                           hooks.json, hooks-codex.json + *.mjs
 ```

--- a/agents/issue-manager.md
+++ b/agents/issue-manager.md
@@ -1,0 +1,10 @@
+---
+name: issue-manager
+description: Organizes GitHub milestones, epics, stories, and progress without unapproved writes.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+Follow the portable `plus-ultra:issue-management` skill exactly. Validate GitHub authentication and
+repository write access before proposing mutations; never perform a GitHub write without explicit
+confirmation, and report every mutation or failure.

--- a/agents/issue-refiner.md
+++ b/agents/issue-refiner.md
@@ -1,0 +1,9 @@
+---
+name: issue-refiner
+description: Refines raw GitHub issues into reviewable implementation briefs.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+Follow the portable `plus-ultra:refine-issues` skill exactly. Read the requested issue, present its
+complete structured proposal, and never edit GitHub state without explicit confirmation.

--- a/agents/roadmap-planner.md
+++ b/agents/roadmap-planner.md
@@ -1,0 +1,9 @@
+---
+name: roadmap-planner
+description: Plans GitHub milestones, epics, and stories from a roadmap brief.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+Follow the portable `plus-ultra:roadmap-planning` skill exactly. Propose the complete issue tree
+and mutation list, then wait for explicit confirmation before changing GitHub state.

--- a/commands/issue-management.md
+++ b/commands/issue-management.md
@@ -1,0 +1,8 @@
+---
+description: Organize and report GitHub milestones, epics, stories, and progress.
+argument-hint: "[request]"
+---
+
+Delegate `$ARGUMENTS` to the `plus-ultra:issue-manager` agent. It must follow the portable
+`plus-ultra:issue-management` skill, including its authentication, permission, and explicit
+confirmation requirements before any GitHub write.

--- a/commands/refine-issues.md
+++ b/commands/refine-issues.md
@@ -1,0 +1,8 @@
+---
+description: Propose a structured brief for a raw GitHub issue.
+argument-hint: "<issue-number>"
+---
+
+Accept exactly one positive issue number. Otherwise explain the valid form and stop without a
+GitHub write. Delegate to `plus-ultra:issue-refiner`, which must follow `plus-ultra:refine-issues`
+and wait for explicit confirmation before editing the issue or its relationships.

--- a/commands/roadmap-planning.md
+++ b/commands/roadmap-planning.md
@@ -1,0 +1,8 @@
+---
+description: Break a roadmap brief or GitHub issue into milestones, epics, and stories.
+argument-hint: "<brief | issue-number>"
+---
+
+Delegate `$ARGUMENTS` to the `plus-ultra:roadmap-planner` agent. It must follow the portable
+`plus-ultra:roadmap-planning` skill and show the complete proposed GitHub mutation list before
+requesting explicit confirmation.

--- a/skills/issue-management/SKILL.md
+++ b/skills/issue-management/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: issue-management
+description: Use when creating, organizing, linking, or reporting GitHub milestones, epics, and stories with the gh CLI.
+---
+
+# GitHub issue management
+
+Use GitHub Issues as the source of truth. A **Milestone** is a release or roadmap horizon; an
+**Epic** is an issue labelled `type:epic`; a **Story** is an executable sub-issue labelled
+`type:story`. Do not use GitHub Projects or an MCP for this workflow.
+
+## Taxonomy
+
+Inspect this deterministic label set before proposing work. Create only absent labels after confirmation;
+never use `--force` to rewrite metadata on an existing label.
+
+| Group | Label | Color | Description |
+| --- | --- | --- | --- |
+| type | `type:epic` | `#8250df` | Product initiative containing stories |
+| type | `type:story` | `#1f6feb` | Executable unit of work |
+| status | `status:backlog` | `#8c959f` | Not ready to start |
+| status | `status:ready` | `#bf8700` | Ready to start |
+| status | `status:in-progress` | `#0969da` | Actively being worked |
+| status | `status:blocked` | `#cf222e` | Cannot progress without resolution |
+| priority | `priority:high` | `#cf222e` | Highest delivery priority |
+| priority | `priority:medium` | `#bf8700` | Normal delivery priority |
+| priority | `priority:low` | `#1a7f37` | Lower delivery priority |
+
+GitHub's `closed` state means completed; do not add a competing done label. Assign a shared
+milestone to each epic and story. Report milestone progress from GitHub and epic progress from its
+open versus closed sub-issues.
+
+Status and priority labels are mutually exclusive namespaces. Setting one **replaces** any existing
+label in that same group: include the removals and addition in the proposal, remove the other labels
+from the same group after confirmation, and preserve type labels and all unrelated labels.
+
+## Safe operating procedure
+
+1. Resolve the target repository, run `gh auth status`, then query the repository's
+   `viewerPermission`. Stop without writing unless it is `WRITE`, `MAINTAIN`, or `ADMIN`.
+2. For read-only requests, list milestones, issues, labels, parents, children, and calculated
+   progress; never prepare an implicit write.
+3. For a requested change, inspect existing labels, milestones, and issue node IDs first. Present
+   every planned label, milestone, issue, edit, and parent-child link with its target repository.
+4. Ask for **explicit confirmation** after the complete mutation list. Do not create, edit, label,
+   close, or link anything before that confirmation.
+5. After confirmation, perform only the approved operations and report every resulting URL or
+   failure. Stop on an unexpected write failure rather than silently retrying or claiming success.
+
+Create missing labels with `gh label create --color <table-color> --description <table-description>`
+and milestones through `gh api`; reuse existing items by name. Create issues through the GitHub
+GraphQL `createIssue` mutation, setting `milestoneId`,
+`labelIds`, and `parentIssueId` when known. Link already-created issues with `addSubIssue`.
+Use GraphQL node IDs rather than issue numbers for `parentIssueId` and `addSubIssue`.
+
+## Commands to support
+
+- Report the current milestone, epic, and story hierarchy and its progress.
+- Propose or create a milestone, epic, or story with the supplied title, body, labels, and parent.
+- Attach an existing story to an existing epic, using `addSubIssue` only after confirmation.
+- Replace supplied status or priority labels without altering unrelated labels.
+
+Never invent dates, assignees, estimates, or priorities. Ask for the missing value or omit it.

--- a/skills/issue-management/agents/openai.yaml
+++ b/skills/issue-management/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Issue Management"
+  short_description: "Organize GitHub milestones, epics, stories, and progress"
+  default_prompt: "Use $issue-management to report and organize this repository's GitHub Issues."

--- a/skills/refine-issues/SKILL.md
+++ b/skills/refine-issues/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: refine-issues
+description: Use when a person-created GitHub issue needs a structured, reviewable implementation brief before work begins.
+---
+
+# Refine GitHub issues
+
+Accept one positive **issue number**. Read the issue, its labels, milestone, parent, and relevant
+repository context. Follow `plus-ultra:issue-management` for repository access and mutation safety.
+
+## Proposal
+
+Classify the issue as a story or epic from its scope, then show a proposed title, labels, milestone,
+and parent only when each is supported by the available context. Replace the body only with this
+reviewable structure:
+
+```markdown
+## Context
+
+## Goal
+
+## Scope
+### In
+### Out
+
+## Acceptance Criteria
+
+## Dependencies
+
+## Risks
+```
+
+Keep uncertain facts as explicit questions, not invented requirements. Do not edit the issue, add
+labels, assign a milestone, or create a parent-child relation until the user gives **explicit confirmation**
+for the displayed proposal. On confirmation, make only those edits and report the
+updated issue URL; GitHub's edit history remains the record of the original intake.

--- a/skills/refine-issues/agents/openai.yaml
+++ b/skills/refine-issues/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Refine Issues"
+  short_description: "Turn a raw GitHub issue into a reviewable implementation brief"
+  default_prompt: "Use $refine-issues to propose a structured brief for GitHub issue #<number>."

--- a/skills/roadmap-planning/SKILL.md
+++ b/skills/roadmap-planning/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: roadmap-planning
+description: Use when a roadmap brief or GitHub issue needs to be broken into milestones, epics, and executable stories.
+---
+
+# Plan a GitHub Issues roadmap
+
+Accept a roadmap brief or an existing issue. If an issue is supplied, read it before planning. Follow
+`plus-ultra:issue-management` for taxonomy, repository access, and mutation safety.
+
+## Decompose before writing
+
+Propose one Milestone, then a tree of Epics and independent Stories. Every Story must state its
+outcome-oriented title, context, acceptance criteria, and dependencies. Keep cross-epic ordering in
+the dependency text; GitHub sub-issues express ownership, not scheduling.
+
+Show the complete tree and a mutation list: labels to create, milestone to create or reuse, each
+epic and story, labels, milestone assignments, and parent-child links. Do not create anything until
+the user gives **explicit confirmation** of that complete proposal.
+
+After confirmation, create or reuse labels and the milestone, then create epics and stories with
+GraphQL `createIssue` and `parentIssueId`; use `addSubIssue` only for pre-existing issues. Report
+all created URLs and any operation that failed. Do not invent dates, assignees, estimates, or priorities; include them only when the user supplied them.

--- a/skills/roadmap-planning/agents/openai.yaml
+++ b/skills/roadmap-planning/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Roadmap Planning"
+  short_description: "Break a roadmap into GitHub milestones, epics, and stories"
+  default_prompt: "Use $roadmap-planning to turn this roadmap into GitHub Issues."

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -379,3 +379,101 @@ test("pr-review workflow is packaged, safe, and available through Claude", () =>
   assert.doesNotMatch(codeReviewer, /\bgh\b/i);
   assert.match(codeReviewer, /Do not modify files/i);
 });
+
+test("GitHub Issues workflows are portable, confirmation-gated, and available through Claude", () => {
+  const workflows = [
+    {
+      name: "issue-management",
+      command: "issue-management",
+      agent: "issue-manager",
+      displayName: "Issue Management",
+    },
+    {
+      name: "refine-issues",
+      command: "refine-issues",
+      agent: "issue-refiner",
+      displayName: "Refine Issues",
+    },
+    {
+      name: "roadmap-planning",
+      command: "roadmap-planning",
+      agent: "roadmap-planner",
+      displayName: "Roadmap Planning",
+    },
+  ];
+
+  const readme = readRelative("README.md");
+  for (const workflow of workflows) {
+    const skillPath = `skills/${workflow.name}/SKILL.md`;
+    const commandPath = `commands/${workflow.command}.md`;
+    const agentPath = `agents/${workflow.agent}.md`;
+    const metadataPath = `skills/${workflow.name}/agents/openai.yaml`;
+
+    assert.ok(existsSync(join(repoRoot, skillPath)), `${skillPath} exists`);
+    assert.ok(existsSync(join(repoRoot, commandPath)), `${commandPath} exists`);
+    assert.ok(existsSync(join(repoRoot, agentPath)), `${agentPath} exists`);
+    assert.ok(existsSync(join(repoRoot, metadataPath)), `${metadataPath} exists`);
+
+    const skill = readRelative(skillPath);
+    const command = readRelative(commandPath);
+    const agent = readRelative(agentPath);
+    const metadata = readRelative(metadataPath);
+    const frontmatter = parseFrontmatter(skill);
+
+    assert.equal(frontmatter.name, workflow.name);
+    assert.match(frontmatter.description, /Use when/i);
+    assert.match(command, new RegExp(`plus-ultra:${workflow.agent}`));
+    assert.match(agent, new RegExp(`^name: ${workflow.agent}$`, "m"));
+    assert.match(agent, new RegExp(`plus-ultra:${workflow.name}`));
+    assert.match(metadata, new RegExp(`display_name: "${workflow.displayName}"`));
+    assert.match(readme, new RegExp(`plus-ultra:${workflow.name}`));
+  }
+
+  const management = readRelative("skills/issue-management/SKILL.md");
+  assert.match(management, /type:epic/);
+  assert.match(management, /type:story/);
+  for (const status of ["backlog", "ready", "in-progress", "blocked"]) {
+    assert.match(management, new RegExp(`status:${status}`));
+  }
+  for (const priority of ["high", "medium", "low"]) {
+    assert.match(management, new RegExp(`priority:${priority}`));
+  }
+  assert.match(management, /gh auth status/);
+  assert.match(management, /ADMIN/);
+  assert.match(management, /explicit confirmation/i);
+  assert.match(management, /createIssue/);
+  assert.match(management, /parentIssueId/);
+  assert.match(management, /addSubIssue/);
+  assert.match(management, /GitHub Projects/i);
+  assert.match(management, /not.*GitHub Projects|GitHub Projects.*not/i);
+  assert.match(management, /replace.*status|status.*replace/i);
+  assert.match(management, /replace.*priority|priority.*replace/i);
+  assert.match(management, /remove.*same group|same group.*remove/i);
+  for (const label of ["type:epic", "type:story", "status:backlog", "priority:high"]) {
+    assert.match(management, new RegExp(`${label}.*#[0-9A-Fa-f]{6}`));
+  }
+
+  const refiner = readRelative("skills/refine-issues/SKILL.md");
+  for (const section of [
+    "Context",
+    "Goal",
+    "Scope",
+    "Acceptance Criteria",
+    "Dependencies",
+    "Risks",
+  ]) {
+    assert.match(refiner, new RegExp(section));
+  }
+  assert.match(refiner, /issue number/i);
+  assert.match(refiner, /explicit confirmation/i);
+  assert.match(refiner, /do not.*edit|never.*edit/i);
+
+  const roadmap = readRelative("skills/roadmap-planning/SKILL.md");
+  assert.match(roadmap, /brief.*issue|issue.*brief/i);
+  assert.match(roadmap, /Milestone/);
+  assert.match(roadmap, /Epic/);
+  assert.match(roadmap, /Story/);
+  assert.match(roadmap, /dependencies/i);
+  assert.match(roadmap, /explicit confirmation/i);
+  assert.match(roadmap, /do not invent.*dates.*assignees.*estimates.*priorities/i);
+});


### PR DESCRIPTION
## At a glance
Adds portable, confirmation-gated GitHub Issue workflows for milestones, epics, stories, roadmap decomposition, and raw issue refinement.

## Context
Closes #12 by making GitHub Issues the source of truth without GitHub Projects or a bundled MCP.

## Summary
- Adds portable skills plus Claude command and agent surfaces.
- Defines deterministic labels, safe permission checks, and parent-child issue linking.

## Testing
- `node --test tests/*.test.mjs` — 17 passing.
- Skill validation, Claude marketplace validation, and clean Codex marketplace installation.

## Risks
No known compatibility risk; live GitHub mutations were not tested because no disposable remote repository was designated.

## Review Guidance
Review the confirmation gate and mutually exclusive status/priority label semantics in `skills/issue-management/SKILL.md`.