### PR TITLE
fix(hooks): reject stale verification results

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,11 @@ nor a bundled GitHub MCP.
   - *secret-scan* (PreToolUse / `git commit`) — blocks a commit whose staged diff contains a
     private key, cloud/API token, or a staged `.env` file.
   - *commit-msg-lint* (PreToolUse / `git commit -m`) — blocks a header that isn't a Conventional Commit.
-  - *commit-gate* (PreToolUse / `git commit`) — blocks unless a test run passed this session (and, in
-    a TypeScript project, a typecheck). Order is flexible: checks any time in the session.
-  - *test-marker* (PostToolUse / Bash) — records a per-session marker when a test or typecheck exits 0.
+  - *commit-gate* (PreToolUse / `git commit`) — blocks unless a test run passed for the current Git
+    working tree this session (and, in a TypeScript project, a typecheck). Order is flexible: checks
+    any time in the session, but code changes require rerunning them.
+  - *test-marker* (PostToolUse / Bash) — records a per-session, Git-tree fingerprinted marker when a
+    test or typecheck exits 0.
   - *pr-description-reminder* (PostToolUse / `git commit`) — reminds you to refresh an open PR
     description after new commits; it never edits GitHub state.
   - *auto-format* (PostToolUse / Write|Edit/apply_patch) — runs `biome check --write` on edited

--- a/hooks/_lib.mjs
+++ b/hooks/_lib.mjs
@@ -1,5 +1,16 @@
 // Shared helpers for plus-ultra hooks. Zero dependencies.
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { resolve, sep } from "node:path";
 
 // Read and parse the hook JSON payload from stdin. Returns {} on empty/invalid.
 export async function readInput() {
@@ -98,4 +109,103 @@ export function isTsProject(root) {
     }
   }
   return false;
+}
+
+function git(root, args) {
+  const result = spawnSync("git", args, {
+    cwd: root,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (result.error || result.status !== 0 || !Buffer.isBuffer(result.stdout)) return null;
+  return result.stdout;
+}
+
+function nullDelimited(buffer) {
+  const values = [];
+  let start = 0;
+  for (let index = 0; index < buffer.length; index += 1) {
+    if (buffer[index] !== 0) continue;
+    if (index > start) values.push(buffer.subarray(start, index));
+    start = index + 1;
+  }
+  return values;
+}
+
+function addHashPart(hash, label, value) {
+  const bytes = Buffer.isBuffer(value) ? value : Buffer.from(String(value));
+  hash.update(label);
+  hash.update("\0");
+  hash.update(String(bytes.length));
+  hash.update("\0");
+  hash.update(bytes);
+}
+
+function fileEntry(root, path) {
+  const relativePath = path.toString("utf8");
+  const absolutePath = resolve(root, relativePath);
+  const rootPrefix = root.endsWith(sep) ? root : `${root}${sep}`;
+  if (absolutePath !== root && !absolutePath.startsWith(rootPrefix)) return null;
+
+  let stat;
+  try {
+    stat = lstatSync(absolutePath);
+  } catch (error) {
+    if (error?.code === "ENOENT" || error?.code === "ENOTDIR") return { type: "missing", mode: 0, value: Buffer.alloc(0) };
+    return null;
+  }
+
+  try {
+    if (stat.isFile()) return { type: "file", mode: stat.mode & 0o7777, value: readFileSync(absolutePath) };
+    if (stat.isSymbolicLink()) {
+      return { type: "symlink", mode: stat.mode & 0o7777, value: readlinkSync(absolutePath, "buffer") };
+    }
+    return { type: "other", mode: stat.mode & 0o7777, value: Buffer.alloc(0) };
+  } catch {
+    return null;
+  }
+}
+
+function addWorktreePaths(hash, root, label, paths) {
+  for (const path of paths.sort(Buffer.compare)) {
+    const entry = fileEntry(root, path);
+    if (!entry) return false;
+    addHashPart(hash, `${label}:path`, path);
+    addHashPart(hash, `${label}:type`, entry.type);
+    addHashPart(hash, `${label}:mode`, entry.mode);
+    addHashPart(hash, `${label}:value`, entry.value);
+  }
+  return true;
+}
+
+function isPluginStatePath(path) {
+  const relativePath = path.toString("utf8");
+  return /^(?:\.claude|\.codex)\/plus-ultra\/state\//.test(relativePath);
+}
+
+// Hash the index and visible worktree state without mutating Git state. A null
+// result means the hook cannot establish a trustworthy verification baseline.
+export function workingTreeFingerprint(root) {
+  try {
+    const requestedRoot = typeof root === "object" ? projectRoot(root) : root || process.cwd();
+    const repository = git(requestedRoot, ["rev-parse", "--show-toplevel"]);
+    if (!repository) return null;
+
+    const repositoryRoot = repository.toString("utf8").trim();
+    if (!repositoryRoot) return null;
+
+    const index = git(repositoryRoot, ["ls-files", "--stage", "-z"]);
+    const tracked = git(repositoryRoot, ["ls-files", "-z"]);
+    const untracked = git(repositoryRoot, ["ls-files", "--others", "--exclude-standard", "-z"]);
+    if (!index || !tracked || !untracked) return null;
+
+    const hash = createHash("sha256");
+    addHashPart(hash, "plus-ultra-working-tree-fingerprint", "v1");
+    addHashPart(hash, "index", index);
+    if (!addWorktreePaths(hash, repositoryRoot, "tracked", nullDelimited(tracked))) return null;
+    const userUntracked = nullDelimited(untracked).filter((path) => !isPluginStatePath(path));
+    if (!addWorktreePaths(hash, repositoryRoot, "untracked", userUntracked)) return null;
+    return hash.digest("hex");
+  } catch {
+    return null;
+  }
 }

--- a/hooks/commit-gate.mjs
+++ b/hooks/commit-gate.mjs
@@ -2,7 +2,16 @@
 // PreToolUse (Bash): block `git commit` unless this session recorded a passing
 // test run — and, in a TypeScript project, a passing typecheck too. Order is
 // flexible: the checks may run any time in the session, not before writing code.
-import { readInput, debug, deny, allow, readMarker, isTsProject, projectRoot } from "./_lib.mjs";
+import {
+  readInput,
+  debug,
+  deny,
+  allow,
+  readMarker,
+  isTsProject,
+  projectRoot,
+  workingTreeFingerprint,
+} from "./_lib.mjs";
 
 const input = await readInput();
 debug("commit-gate", input);
@@ -17,15 +26,28 @@ if (/--dry-run\b/.test(c)) allow();
 
 const root = projectRoot(input);
 const marker = readMarker(input?.session_id, input);
+const fingerprint = workingTreeFingerprint(root);
 
 const missing = [];
-if (!marker.testPassedAt) missing.push("a passing test run (must exit 0)");
-if (isTsProject(root) && !marker.typecheckPassedAt)
-  missing.push("a passing typecheck (e.g. `tsc --noEmit` or your `typecheck` script)");
+const stale = [];
+if (!marker.testPassedAt || !marker.testPassedFor)
+  missing.push("a passing test run (must exit 0)");
+else if (!fingerprint || marker.testPassedFor !== fingerprint)
+  stale.push("Verification stale: code changed since last successful test run.");
 
-if (missing.length === 0) allow();
+if (isTsProject(root)) {
+  if (!marker.typecheckPassedAt || !marker.typecheckPassedFor)
+    missing.push("a passing typecheck (e.g. `tsc --noEmit` or your `typecheck` script)");
+  else if (!fingerprint || marker.typecheckPassedFor !== fingerprint)
+    stale.push("Verification stale: code changed since last successful typecheck.");
+}
 
+if (missing.length === 0 && stale.length === 0) allow();
+
+const problems = [];
+if (missing.length > 0) problems.push(`this session is missing ${missing.join(" and ")}.`);
+problems.push(...stale);
 deny(
-  `Blocked by plus-ultra commit-gate: this session is missing ${missing.join(" and ")}. ` +
-    `Run ${missing.length > 1 ? "them" : "it"} (exit 0) before committing, then retry.`
+  `Blocked by plus-ultra commit-gate: ${problems.join(" ")} ` +
+    "Run the required checks (exit 0) before committing, then retry."
 );

--- a/hooks/test-marker.mjs
+++ b/hooks/test-marker.mjs
@@ -2,7 +2,7 @@
 // PostToolUse (Bash): when a test run OR a typecheck completes successfully,
 // record it in the per-session marker that commit-gate reads. Fail-closed: only
 // record on a clear success signal.
-import { readInput, debug, mergeMarker } from "./_lib.mjs";
+import { readInput, debug, mergeMarker, projectRoot, workingTreeFingerprint } from "./_lib.mjs";
 
 const input = await readInput();
 debug("test-marker", input);
@@ -68,9 +68,18 @@ if (input?.tool_error === true || resp.interrupted === true) {
 
 if (!passed) process.exit(0);
 
+const fingerprint = workingTreeFingerprint(projectRoot(input));
+if (!fingerprint) process.exit(0);
+
 const now = new Date().toISOString();
 const patch = {};
-if (isTest) patch.testPassedAt = now;
-if (isTypecheck) patch.typecheckPassedAt = now;
+if (isTest) {
+  patch.testPassedAt = now;
+  patch.testPassedFor = fingerprint;
+}
+if (isTypecheck) {
+  patch.typecheckPassedAt = now;
+  patch.typecheckPassedFor = fingerprint;
+}
 mergeMarker(sessionId, patch, input);
 process.exit(0);

--- a/tests/hooks.test.mjs
+++ b/tests/hooks.test.mjs
@@ -33,6 +33,58 @@ function makeTempProject() {
   return root;
 }
 
+function runCommand(command, args, cwd) {
+  const result = spawnSync(command, args, { cwd, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function makeGitProject({ typescript = false } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "plus-ultra-git-"));
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(join(root, "src", "app.mjs"), "export const value = 1;\n");
+  if (typescript) writeFileSync(join(root, "tsconfig.json"), "{}\n");
+
+  runCommand("git", ["init", "--initial-branch=main"], root);
+  runCommand("git", ["config", "user.email", "hooks@example.com"], root);
+  runCommand("git", ["config", "user.name", "Hook tests"], root);
+  runCommand("git", ["add", "."], root);
+  runCommand("git", ["commit", "-m", "Initial commit"], root);
+  return root;
+}
+
+function markerPayload(command, sessionId = "session-1") {
+  return {
+    hook_event_name: "PostToolUse",
+    model: "gpt-5.5",
+    permission_mode: "default",
+    session_id: sessionId,
+    tool_name: "Bash",
+    tool_input: { command },
+    tool_response: { exitCode: 0 },
+    tool_use_id: "tool-1",
+    transcript_path: null,
+    turn_id: "turn-1",
+  };
+}
+
+function commitPayload(sessionId = "session-1") {
+  return {
+    hook_event_name: "PreToolUse",
+    model: "gpt-5.5",
+    permission_mode: "default",
+    session_id: sessionId,
+    tool_name: "Bash",
+    tool_input: { command: "git commit -m 'feat: guarded commit'" },
+    tool_use_id: "tool-1",
+    transcript_path: null,
+    turn_id: "turn-1",
+  };
+}
+
+function denialReason(output) {
+  return JSON.parse(output).hookSpecificOutput.permissionDecisionReason;
+}
+
 test("session-start emits Codex additional context JSON", () => {
   const cwd = makeTempProject();
   try {
@@ -105,7 +157,7 @@ test("auto-format formats files from Codex apply_patch payloads", () => {
 });
 
 test("test marker writes Codex session state under .codex", () => {
-  const cwd = mkdtempSync(join(tmpdir(), "plus-ultra-marker-"));
+  const cwd = makeGitProject();
   try {
     runHook(
       "test-marker.mjs",
@@ -129,6 +181,96 @@ test("test marker writes Codex session state under .codex", () => {
       readFileSync(join(cwd, ".codex", "plus-ultra", "state", "session-1.json"), "utf8")
     );
     assert.equal(typeof marker.testPassedAt, "string");
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("test marker does not record a verification when the Git tree cannot be fingerprinted", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "plus-ultra-marker-"));
+  try {
+    runHook("test-marker.mjs", markerPayload("pnpm test"), { cwd });
+
+    assert.equal(existsSync(join(cwd, ".codex", "plus-ultra", "state", "session-1.json")), false);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("commit gate accepts a successful test for the unchanged Git tree", () => {
+  const cwd = makeGitProject();
+  try {
+    runHook("test-marker.mjs", markerPayload("pnpm test"), { cwd });
+
+    const marker = JSON.parse(
+      readFileSync(join(cwd, ".codex", "plus-ultra", "state", "session-1.json"), "utf8")
+    );
+    assert.equal(typeof marker.testPassedFor, "string");
+    assert.equal(runHook("commit-gate.mjs", commitPayload(), { cwd }), "");
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("commit gate rejects a test verification after an unstaged tracked change", () => {
+  const cwd = makeGitProject();
+  try {
+    runHook("test-marker.mjs", markerPayload("pnpm test"), { cwd });
+    writeFileSync(join(cwd, "src", "app.mjs"), "export const value = 2;\n");
+
+    const output = runHook("commit-gate.mjs", commitPayload(), { cwd });
+    assert.equal(
+      denialReason(output),
+      "Blocked by plus-ultra commit-gate: Verification stale: code changed since last successful test run. " +
+        "Run the required checks (exit 0) before committing, then retry."
+    );
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("commit gate rejects a test verification after a staged change", () => {
+  const cwd = makeGitProject();
+  try {
+    runHook("test-marker.mjs", markerPayload("pnpm test"), { cwd });
+    writeFileSync(join(cwd, "src", "app.mjs"), "export const value = 2;\n");
+    runCommand("git", ["add", "src/app.mjs"], cwd);
+
+    const output = runHook("commit-gate.mjs", commitPayload(), { cwd });
+    assert.match(output, /Verification stale: code changed since last successful test run\./);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("commit gate rejects a test verification after an untracked change", () => {
+  const cwd = makeGitProject();
+  try {
+    runHook("test-marker.mjs", markerPayload("pnpm test"), { cwd });
+    writeFileSync(join(cwd, "new-file.mjs"), "export const value = 2;\n");
+
+    const output = runHook("commit-gate.mjs", commitPayload(), { cwd });
+    assert.match(output, /Verification stale: code changed since last successful test run\./);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("commit gate requires a matching typecheck verification in TypeScript projects", () => {
+  const cwd = makeGitProject({ typescript: true });
+  try {
+    runHook("test-marker.mjs", markerPayload("pnpm test"), { cwd });
+    runHook("test-marker.mjs", markerPayload("pnpm typecheck"), { cwd });
+
+    const marker = JSON.parse(
+      readFileSync(join(cwd, ".codex", "plus-ultra", "state", "session-1.json"), "utf8")
+    );
+    assert.equal(typeof marker.typecheckPassedFor, "string");
+    assert.equal(runHook("commit-gate.mjs", commitPayload(), { cwd }), "");
+
+    writeFileSync(join(cwd, "src", "app.mjs"), "export const value = 2;\n");
+    const output = runHook("commit-gate.mjs", commitPayload(), { cwd });
+    assert.match(output, /Verification stale: code changed since last successful typecheck\./);
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #15.

`commit-gate` now accepts test and typecheck markers only when their SHA-256 Git-tree fingerprint still matches the current candidate state.
The fingerprint covers index, tracked worktree files, and non-ignored user untracked files while excluding Plus Ultra’s ephemeral marker state.
Regression coverage verifies unchanged, staged, unstaged, untracked, TypeScript, and unavailable-Git scenarios; `node --test tests/hooks.test.mjs` and `claude plugin validate .` pass.