### PR TITLE
feat(issues): prefer native gh hierarchy commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ and `/plus-ultra:roadmap-planning <brief | issue-number>`. Every GitHub write re
 explicit confirmation in that execution. These workflows intentionally use neither GitHub Projects
 nor a bundled GitHub MCP.
 
+Issue hierarchy uses native `gh issue` operations on GitHub CLI v2.94.0 and later. On older
+installations, GraphQL is a fallback only for the missing hierarchy operation.
+
 ## What it adds
 
 - **Skills (portable, `plus-ultra:*` when installed as a plugin):**

--- a/skills/issue-management/SKILL.md
+++ b/skills/issue-management/SKILL.md
@@ -9,6 +9,19 @@ Use GitHub Issues as the source of truth. A **Milestone** is a release or roadma
 **Epic** is an issue labelled `type:epic`; a **Story** is an executable sub-issue labelled
 `type:story`. Do not use GitHub Projects or an MCP for this workflow.
 
+## Hierarchy capabilities
+
+GitHub CLI v2.94.0 introduced native issue hierarchy operations. Detect each capability from the
+relevant `gh issue ... --help` output; do not infer support by parsing the installed version.
+
+- New sub-issue: `gh issue create --parent <parent>`.
+- Existing issue link: `gh issue edit <parent> --add-sub-issue <child>`.
+- Hierarchy report: `gh issue view <issue> --json parent,subIssues,subIssuesSummary`.
+
+Use the native operation whenever its flag or JSON fields are present. If a required capability is
+absent, use GraphQL only as the fallback for that hierarchy operation. This keeps v2.92.0-era
+installations usable without making GraphQL the preferred path.
+
 ## Taxonomy
 
 Inspect this deterministic label set before proposing work. Create only absent labels after confirmation;
@@ -40,24 +53,35 @@ from the same group after confirmation, and preserve type labels and all unrelat
    `viewerPermission`. Stop without writing unless it is `WRITE`, `MAINTAIN`, or `ADMIN`.
 2. For read-only requests, list milestones, issues, labels, parents, children, and calculated
    progress; never prepare an implicit write.
-3. For a requested change, inspect existing labels, milestones, and issue node IDs first. Present
-   every planned label, milestone, issue, edit, and parent-child link with its target repository.
+3. For a requested change, inspect existing labels and milestones first. Inspect issue node IDs only when a missing hierarchy capability requires the GraphQL fallback. Present every planned label,
+   milestone, issue, edit, and parent-child link with its target repository.
 4. Ask for **explicit confirmation** after the complete mutation list. Do not create, edit, label,
    close, or link anything before that confirmation.
 5. After confirmation, perform only the approved operations and report every resulting URL or
    failure. Stop on an unexpected write failure rather than silently retrying or claiming success.
 
 Create missing labels with `gh label create --color <table-color> --description <table-description>`
-and milestones through `gh api`; reuse existing items by name. Create issues through the GitHub
-GraphQL `createIssue` mutation, setting `milestoneId`,
-`labelIds`, and `parentIssueId` when known. Link already-created issues with `addSubIssue`.
-Use GraphQL node IDs rather than issue numbers for `parentIssueId` and `addSubIssue`.
+and milestones through `gh api`; reuse existing items by name. Create every issue with `gh issue
+create`, passing its title, body, labels, and milestone. When `--parent` is available, pass the
+parent issue number or URL during creation.
+
+For an existing issue, link it with `gh issue edit <parent> --add-sub-issue <child>` when that flag
+is available. For hierarchy reports, use the structured `parent`, `subIssues`, and
+`subIssuesSummary` JSON fields when available; use the summary rather than scraping terminal text.
+
+If `--parent` is absent, create the issue with `gh issue create` and then attach it with the native
+`--add-sub-issue` flag when available. If the needed linking flag is absent, look up only the
+parent and child node IDs and invoke the GraphQL `addSubIssue` mutation as a fallback. If the JSON
+hierarchy fields are absent, issue a read-only GraphQL query for `parent`, `subIssues`, and
+`subIssuesSummary` instead. Do not use GraphQL for ordinary issue creation, labels, milestones, or
+reporting when the corresponding native capability exists.
 
 ## Commands to support
 
 - Report the current milestone, epic, and story hierarchy and its progress.
 - Propose or create a milestone, epic, or story with the supplied title, body, labels, and parent.
-- Attach an existing story to an existing epic, using `addSubIssue` only after confirmation.
+- Attach an existing story to an existing epic with `gh issue edit`; use GraphQL only when that
+  native hierarchy capability is absent, and only after confirmation.
 - Replace supplied status or priority labels without altering unrelated labels.
 
 Never invent dates, assignees, estimates, or priorities. Ask for the missing value or omit it.

--- a/skills/roadmap-planning/SKILL.md
+++ b/skills/roadmap-planning/SKILL.md
@@ -19,5 +19,14 @@ epic and story, labels, milestone assignments, and parent-child links. Do not cr
 the user gives **explicit confirmation** of that complete proposal.
 
 After confirmation, create or reuse labels and the milestone, then create epics and stories with
-GraphQL `createIssue` and `parentIssueId`; use `addSubIssue` only for pre-existing issues. Report
-all created URLs and any operation that failed. Do not invent dates, assignees, estimates, or priorities; include them only when the user supplied them.
+`gh issue create`, passing title, body, labels, and milestone. GitHub CLI v2.94.0 introduced native
+hierarchy operations: detect `--parent` in `gh issue create --help` and `--add-sub-issue` in
+`gh issue edit --help` rather than parsing the installed version.
+
+Create each story with `gh issue create --parent <parent>` when that capability is available. If
+`--parent` is absent, create the story with `gh issue create`, then attach it with
+`gh issue edit <parent> --add-sub-issue <child>` when that capability is available. If the needed
+native capability is absent, look up the parent and child node IDs and use GraphQL `addSubIssue` as
+the hierarchy fallback only.
+Report all created URLs and any operation that failed. Do not invent dates, assignees, estimates, or
+priorities; include them only when the user supplied them.

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -441,9 +441,14 @@ test("GitHub Issues workflows are portable, confirmation-gated, and available th
   assert.match(management, /gh auth status/);
   assert.match(management, /ADMIN/);
   assert.match(management, /explicit confirmation/i);
-  assert.match(management, /createIssue/);
-  assert.match(management, /parentIssueId/);
-  assert.match(management, /addSubIssue/);
+  assert.match(management, /v2\.94\.0/);
+  assert.match(management, /gh issue create --parent/);
+  assert.match(management, /gh issue edit <parent> --add-sub-issue <child>/);
+  assert.match(management, /gh issue view <issue> --json parent,subIssues,subIssuesSummary/);
+  assert.match(management, /capabilit(?:y|ies).*absent|absent.*capabilit(?:y|ies)/i);
+  assert.match(management, /GraphQL.*fallback|fallback.*GraphQL/i);
+  assert.match(management, /node IDs only.*?fallback/i);
+  assert.doesNotMatch(management, /Create issues through the GitHub\s+GraphQL/i);
   assert.match(management, /GitHub Projects/i);
   assert.match(management, /not.*GitHub Projects|GitHub Projects.*not/i);
   assert.match(management, /replace.*status|status.*replace/i);
@@ -469,11 +474,22 @@ test("GitHub Issues workflows are portable, confirmation-gated, and available th
   assert.match(refiner, /do not.*edit|never.*edit/i);
 
   const roadmap = readRelative("skills/roadmap-planning/SKILL.md");
+  const normalizedRoadmap = roadmap.replace(/\s+/g, " ");
   assert.match(roadmap, /brief.*issue|issue.*brief/i);
   assert.match(roadmap, /Milestone/);
   assert.match(roadmap, /Epic/);
   assert.match(roadmap, /Story/);
   assert.match(roadmap, /dependencies/i);
   assert.match(roadmap, /explicit confirmation/i);
-  assert.match(roadmap, /do not invent.*dates.*assignees.*estimates.*priorities/i);
+  assert.match(normalizedRoadmap, /do not invent.*dates.*assignees.*estimates.*priorities/i);
+  assert.match(roadmap, /v2\.94\.0/);
+  assert.match(roadmap, /gh issue create --parent/);
+  assert.match(roadmap, /gh issue edit <parent> --add-sub-issue <child>/);
+  assert.match(roadmap, /capabilit(?:y|ies).*absent|absent.*capabilit(?:y|ies)/i);
+  assert.match(normalizedRoadmap, /GraphQL.*fallback|fallback.*GraphQL/i);
+
+  const issueWorkflows = markdownSection(readme, "GitHub Issue workflows");
+  assert.match(issueWorkflows, /v2\.94\.0/);
+  assert.match(issueWorkflows, /native.*hierarch|hierarch.*native/i);
+  assert.match(issueWorkflows, /GraphQL.*fallback|fallback.*GraphQL/i);
 });


### PR DESCRIPTION
## At a glance
Issue workflows now prefer native `gh issue` hierarchy operations while retaining a capability-scoped GraphQL fallback for older CLIs. This reduces manual GraphQL usage without changing confirmation or permission safeguards.

## Context
Closes #21.

## Summary
- Detects native creation, linking, and structured hierarchy-reporting capabilities.
- Documents the v2.94.0 native baseline and tests the native-first/fallback guidance.

## Testing
- `node --test tests/skills.test.mjs`
- `node --test tests/hooks.test.mjs`
- `claude plugin validate .`
- Clean `codex plugin marketplace add` and `codex plugin add` installation.

## Risks
None known; older GitHub CLI versions retain the GraphQL hierarchy fallback.

## Review Guidance
Review the capability branches in the two portable issue skills, particularly that node IDs are requested only for the GraphQL fallback.