### PR TITLE
feat(pr): propagate Issue-Spec traceability

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,15 @@ installations, GraphQL is a fallback only for the missing hierarchy operation.
     immutable data, explicit error values, and side-effect isolation.
   - *conventional-commits* — the commit message format (enforced by the commit-msg-lint hook).
   - *pull-request-descriptions* — drafts reviewer-focused PR bodies with a human-first overview and
-    conditional Mermaid diagrams, then connects context, summary, testing, risks, and review guidance.
+    conditional Mermaid diagrams, then connects context, Issue–Spec traceability, summary, testing,
+    risks, and review guidance. `Refs #N` is the safe default; `Closes #N` is reserved for a
+    verifiably complete `type:story` contract.
   - *pr-review* — reviews a GitHub pull request against its linked approved technical contract:
-    an approved spec whose optional Issue # matches the PR’s closing Issue is selected first. It posts
-    deduplicated right-side findings and maintains a canonical tagged review summary. It uses the
-    current branch’s PR by default; pass a positive PR number to override it. This workflow requires
-    GitHub write access through `gh`.
+    exactly one approved spec whose optional Issue # matches a PR closing Issue is selected through
+    `closingIssuesReferences` at the remote head. Missing or ambiguous associations remain delegated
+    to #17. It posts deduplicated right-side findings and maintains a canonical tagged review summary.
+    It uses the current branch’s PR by default; pass a positive PR number to override it. This
+    workflow requires GitHub write access through `gh`.
   - *issue-management*, *refine-issues*, *roadmap-planning* — GitHub Issues workflows for native
     milestone → epic → story planning, raw issue refinement, and progress reporting. Remote writes
     are always proposal-first and confirmation-gated.

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -7,7 +7,10 @@ model: sonnet
 
 You are the GitHub PR reviewer. Follow the portable `plus-ultra:pr-review` skill exactly. Validate
 the optional PR number, GitHub authentication/write access, and PR metadata (including
-`closingIssuesReferences`) before any write. At the remote PR head, select exactly one approved
-technical contract whose `issue:` matches a closing Issue reference; otherwise use the sole approved
-spec. If selection remains ambiguous, list every approved candidate and stop before writes. Use `gh`
-only as specified by that skill; preserve other reviewers’ threads and report every mutation or skip.
+`closingIssuesReferences`) before any write. Obtain closing Issues with `gh pr view <pr-number>
+--json closingIssuesReferences`; do not parse a closing keyword or use GraphQL to discover them. At
+the remote PR head, select exactly one approved technical contract whose `issue:` matches a closing
+Issue. Exclude draft and superseded specs; never substitute a sole unlinked approved spec. If the
+canonical match is missing or ambiguous, list every approved candidate, delegate fallback resolution
+to #17, and stop before writes. Use `gh` only as specified by that skill; preserve other reviewers’
+threads and report every mutation or skip.

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -15,17 +15,19 @@ open. This is a writing workflow: it needs authenticated GitHub write access. Us
    branch. Reject zero, negative, non-integer, or extra arguments before any write.
 2. Run `gh auth status`; stop before writes if authentication or GitHub write authorization is not
    available.
-3. Resolve and validate the PR with `gh pr view <number>` (or `gh pr view` for no argument). Fetch
-   remote metadata including its number, base ref, head ref, head repository, state, URL,
-   `headRefOid`, and `closingIssuesReferences`. Stop before writes if the PR cannot be found, is
-   closed, or is not reviewable.
+3. Resolve and validate the PR with `gh pr view <number>` (or `gh pr view` for no argument). First
+   obtain closing Issues with `gh pr view <pr-number> --json closingIssuesReferences`; fetch its
+   number, base ref, head ref, head repository, state, URL, and `headRefOid` in the same or a
+   subsequent PR-metadata request. Stop before writes if the PR cannot be found, is closed, or is
+   not reviewable. Do not parse a closing keyword from the PR body. Do not use GraphQL to discover
+   closing Issues.
 4. From the **remote PR head**, list `specs/` and fetch each candidate spec through the GitHub API
-   at `headRefOid`; do not read the local checkout as the source of truth. Consider only approved
-   specs (`status: approved`) and exclude superseded specs. Select exactly one approved spec whose
-   `issue:` matches a PR `closingIssuesReferences` Issue. If no unique Issue match exists, select
-   the only approved spec when there is exactly one. If selection fails—including zero approved candidates
-   or no approved specs, or unresolved ambiguity—report every approved candidate (if any) and stop before
-   any GitHub writes; for ambiguous candidates, explicitly stop before writes. Read the selected
+   at `headRefOid`; do not read the local checkout as the source of truth. For every closing Issue,
+   collect only approved specs (`status: approved`) whose `issue:` matches that Issue; exclude draft
+   and superseded specs. Select a contract only when exactly one approved spec matches the closing
+   Issues. Do not substitute an unlinked or merely sole approved spec when that canonical match is
+   missing. If zero or several candidates match, report every approved candidate and delegate the
+   missing or ambiguous resolution fallback to #17; stop before any GitHub writes. Read the selected
    approved spec's acceptance criteria, interface contracts, architecture boundaries, functional core,
    test plan, and risks.
 

--- a/skills/pull-request-descriptions/SKILL.md
+++ b/skills/pull-request-descriptions/SKILL.md
@@ -17,10 +17,12 @@ where reviewers should focus.
    - `git diff origin/main...` or the target branch named by the user
    - related spec, issue, design doc, or acceptance criteria when present
    - test, lint, typecheck, build, or manual verification output from this branch
-2. Separate facts from inference. If the diff does not prove something, phrase it as an assumption
+2. Resolve Traceability when an approved spec has an `issue:` link. Preserve the Issue number and
+   spec path; do not invent either from branch names or commit messages.
+3. Separate facts from inference. If the diff does not prove something, phrase it as an assumption
    or omit it.
-3. Write for the reviewer who has not followed the implementation.
-4. Keep the body concise, but do not hide risk, missing verification, or follow-up work.
+4. Write for the reviewer who has not followed the implementation.
+5. Keep the body concise, but do not hide risk, missing verification, or follow-up work.
 
 ## Recommended Template
 
@@ -35,6 +37,11 @@ Use this shape unless the repository has its own required PR template:
 
 ## Context
 [Why this change is needed. Link or name the spec/issue when applicable.]
+
+## Traceability
+- Issue: #<number>
+- Spec: `specs/<path>` (approved)
+- Refs #<number>
 
 ## Summary
 - [User-visible or maintainer-visible change]
@@ -76,7 +83,26 @@ by the diff, issue/spec, or verified behavior.
   `stateDiagram-v2`.
 
 **Context:** Explain the problem and intent in one short paragraph. Avoid repeating the branch name
-or commit subject. If this PR implements a spec, mention the spec path and status.
+or commit subject.
+
+**Traceability:** Add one group for every independently resolved linked Issue and spec. Write
+`Issue: #<number>` and `Spec: specs/<path>` (approved) when the approved spec is available. For
+each Issue, use exactly one of `Refs #<number>` or `Closes #<number>` and evaluate each Issue
+independently. Use `Refs #<number>` by default, including incremental PRs; assess the resulting
+branch state against its base, not whether a single diff contains every implementation step.
+
+Upgrade one Issue from `Refs #<number>` to `Closes #<number>` only when all of this is demonstrable:
+
+1. The Issue has the `type:story` label; epics never receive a closing keyword.
+2. An approved spec is linked through its `issue:` frontmatter.
+3. The resulting change satisfies the complete scope and acceptance criteria of that Issue and spec.
+4. The final `plus-ultra:pr-review` verdict is `ready` with no blockers relative to that contract.
+5. No required work for that story is explicitly deferred to another PR.
+
+At PR creation, keep `Refs #<number>` until the final review provides the needed evidence. If any
+condition is missing, cannot be demonstrated, or is ambiguous, retain `Refs #<number>` and never
+use `Closes #<number>`. If an Issue is known but no approved linked spec is available, include its
+`Issue: #<number>` and `Refs #<number>` without inventing a Spec line.
 
 **Summary:** Prefer bullets that describe externally meaningful behavior or durable code boundaries.
 Avoid file-by-file narration unless the file organization is the point of the PR.

--- a/specs/002-propagate-issue-spec-traceability-to-prs.md
+++ b/specs/002-propagate-issue-spec-traceability-to-prs.md
@@ -1,0 +1,114 @@
+---
+title: Propagate Issue–Spec traceability into pull requests
+status: approved # draft → approved → superseded
+issue: 31
+created: 2026-09-05
+---
+
+# 002 — Propagate Issue–Spec traceability into pull requests
+
+## Problem
+
+PR creation and review need a deterministic link from a GitHub Issue to its approved technical
+contract without copying product-work state into specs. A partial PR must not accidentally close a
+story merely because it references that story or its spec.
+
+## Goals / Non-goals
+
+**Goals**
+
+- Preserve linked Issue and approved spec path in PR descriptions.
+- Use `Refs #<number>` for safe, incremental PR traceability and `Closes #<number>` only when the
+  resulting branch fully completes an executable story contract.
+- Resolve a review contract from PR closing Issues and remote-head approved specs before any fallback.
+- Keep GitHub Issues authoritative for product-work status and specs authoritative for technical
+  contracts.
+
+**Non-goals**
+
+- Add a PR-creation command, a CI validator, a hook, or a second product-state store.
+- Close Issues automatically or infer a closing keyword from branch names, commits, or PR prose.
+- Implement missing or ambiguous PR-to-spec fallback behavior; issue #17 owns that work.
+
+## Acceptance criteria
+
+- [x] PR-description guidance includes `Issue: #N`, approved `Spec: specs/...`, and exactly one of
+      `Refs #N` or `Closes #N` per independently resolved Issue when traceability is available.
+- [x] `Closes #N` requires a `type:story` Issue, an approved linked spec, complete scope and
+      acceptance criteria at the resulting branch state, a `ready` final review with no contract
+      blockers, and no required deferred work.
+- [x] Incremental PRs may use `Refs #N`; the closing decision evaluates branch state against the
+      base, not only the individual diff, and ambiguity never produces `Closes #N`.
+- [x] PR review obtains closing Issues with `gh pr view <pr-number> --json closingIssuesReferences`,
+      reads candidate specs at the remote PR head, and selects only one approved Issue-matched spec.
+- [x] Deterministic review resolution never parses closing-keyword text or uses GraphQL to discover
+      closing Issues; it excludes draft and superseded specs and delegates missing or ambiguous
+      resolution to #17 before writes.
+- [x] README and regression tests describe and enforce the portable workflow.
+
+## Interface contracts
+
+PR bodies use this traceability shape when an approved linked spec is available:
+
+```markdown
+## Traceability
+- Issue: #42
+- Spec: `specs/002-example.md` (approved)
+- Refs #42
+```
+
+Replace the final line with `Closes #42` only after every closing condition is demonstrable. For
+multiple stories, include a separate group and decide each relationship independently.
+
+The review workflow's canonical discovery command is:
+
+```sh
+gh pr view <pr-number> --json closingIssuesReferences
+```
+
+It selects a contract only if all Issue-matched, remote-head approved candidates total exactly one.
+
+## Architecture boundaries
+
+`skills/pull-request-descriptions/SKILL.md` owns author-facing traceability and closing guidance.
+`skills/pr-review/SKILL.md` owns remote review-contract selection; the Claude-only reviewer agent
+mirrors that portable skill. GitHub API and `gh` access remain workflow steps, while no hook or
+local spec parser performs network activity.
+
+## Functional core
+
+The workflow's decision is deterministic from Issue labels, approved linked spec frontmatter, the
+base-to-head resulting state, final review verdict, and explicitly deferred work. Its conservative
+default is `Refs`: unavailable evidence maps to a non-closing relationship rather than a guessed
+state transition.
+
+## Data model
+
+```yaml
+issue: 31 # optional numeric GitHub Issue link in approved spec frontmatter
+```
+
+```markdown
+Issue: #<number>
+Spec: `specs/<path>` (approved)
+Refs #<number> | Closes #<number>
+```
+
+The PR body stores only a GitHub reference and spec path; it does not mirror Issue status.
+
+## Test plan
+
+- Assert the description template and guidance require the traceability shape, conservative default,
+  story label, complete-contract evidence, final `ready` review, and independent multi-Issue choice.
+- Assert the review skill and Claude agent use `closingIssuesReferences`, remote `headRefOid`, unique
+  approved linked candidates, no closing-keyword parsing, no GraphQL Issue discovery, and #17 handoff.
+- Run the repository Node test suite, diff check, plugin validation, and clean Codex packaging install.
+
+## Risks
+
+- A reviewer can overstate contract completeness; requiring explicit evidence and defaulting to
+  `Refs` avoids premature Issue closure.
+- A PR can reference multiple stories but yield multiple approved contracts; deterministic review
+  intentionally stops and leaves that resolution to #17.
+- GitHub's closing syntax is meaningful only on merge, so PR authors must refresh the relationship
+  after the final review rather than declaring closure at the start of an incremental PR.

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -101,6 +101,7 @@ test("pull-request-descriptions skill is packaged and discoverable", () => {
 
   for (const expectedSection of [
     "Context",
+    "Traceability",
     "Summary",
     "Testing",
     "Risks",
@@ -127,6 +128,7 @@ test("pull-request-descriptions leads with a human-first overview and conditiona
     "At a glance",
     "Diagram",
     "Context",
+    "Traceability",
     "Summary",
     "Testing",
     "Risks",
@@ -170,6 +172,26 @@ test("pull-request-descriptions leads with a human-first overview and conditiona
   assert.match(readme, /conditional Mermaid diagrams/i);
   assert.match(metadata, /human-first overview/i);
   assert.match(metadata, /conditional Mermaid diagrams/i);
+});
+
+test("pull-request-descriptions preserve Issue-Spec traceability without closing partial stories", () => {
+  const skill = readRelative("skills/pull-request-descriptions/SKILL.md");
+  const readme = readRelative("README.md");
+  const normalized = skill.replace(/\s+/g, " ");
+
+  assert.match(skill, /Issue: #<number>/);
+  assert.match(skill, /Spec: `specs\/<path>`/);
+  assert.match(skill, /Refs #<number>/);
+  assert.match(skill, /Closes #<number>/);
+  assert.match(normalized, /exactly one of `Refs #<number>` or `Closes #<number>`.*?each Issue independently/i);
+  assert.match(normalized, /`type:story`/i);
+  assert.match(normalized, /approved.*?spec.*?linked/i);
+  assert.match(normalized, /scope.*?acceptance criteria.*?complete/i);
+  assert.match(normalized, /`ready`.*?no blockers/i);
+  assert.match(normalized, /no required work.*?deferred/i);
+  assert.match(normalized, /state.*?against.*?base/i);
+  assert.match(normalized, /ambigu(?:ity|ous).*?`Refs #<number>`.*?never.*?`Closes #<number>`/i);
+  assert.match(readme, /Refs #N.*?Closes #N|Closes #N.*?Refs #N/i);
 });
 
 test("pull-request-descriptions demonstrates diagram decisions for common review scenarios", () => {
@@ -391,9 +413,15 @@ test("pr-review workflow is packaged, safe, and available through Claude", () =>
   assert.match(skill, /spec.*GitHub API|GitHub API.*spec/i);
   assert.match(skill, /approved spec/i);
   assert.match(skill, /closingIssuesReferences/);
-  assert.match(skill, /before writes if.*ambiguous|ambiguous.*before writes/i);
-  assert.match(skill, /no approved candidates|zero approved candidates|no approved specs|zero approved specs/i);
-  assert.match(skill, /selection fails[\s\S]*stop before\s+(?:any\s+)?GitHub writes|stop before writes.*selection fails/i);
+  assert.match(skill, /gh pr view <pr-number> --json closingIssuesReferences/);
+  assert.match(skill, /exactly one approved spec matches[\s\S]*?closing\s+Issues/i);
+  assert.match(skill, /Do not parse.*?closing keyword/i);
+  assert.match(skill, /Do not use GraphQL.*?discover\s+closing Issues/i);
+  assert.match(skill, /delegate[\s\S]*?#17/i);
+  const normalizedReview = skill.replace(/\s+/g, " ");
+  assert.match(normalizedReview, /before writes if.*ambiguous|ambiguous.*before writes/i);
+  assert.match(normalizedReview, /zero or several candidates match/i);
+  assert.match(normalizedReview, /zero or several candidates match.*?stop before any GitHub writes/i);
   assert.doesNotMatch(skill, /status: in-progress/);
   assert.match(codeReviewer, /status: approved/);
   assert.match(codeReviewer, /explicitly select|ask.*select/i);
@@ -417,6 +445,9 @@ test("pr-review workflow is packaged, safe, and available through Claude", () =>
   assert.match(agent, /^name: pr-reviewer$/m);
   assert.match(agent, /^tools: .*Bash/m);
   assert.match(agent, /plus-ultra:pr-review/);
+  assert.match(agent, /exactly one approved[\s\S]*?closing\s+Issue/i);
+  assert.match(agent, /Do not parse.*?closing keyword/i);
+  assert.match(agent, /#17/);
 
   assert.match(readme, /plus-ultra:pr-review/);
   assert.match(readme, /\/plus-ultra:pr-review \[pr-number\]/);


### PR DESCRIPTION
## At a glance

Adds deterministic Issue–Spec traceability to PR authoring and review while retaining `Refs #31` until the full story is demonstrably complete.

## Diagram

```mermaid
flowchart LR
  Issue[GitHub Issue] --> Description[PR description]
  Issue --> Spec[Approved spec]
  Description --> Review[PR review]
  Spec --> Review
```

## Traceability

- Issue: #31
- Spec: `specs/002-propagate-issue-spec-traceability-to-prs.md` (approved)
- Refs #31

## Summary

- Adds conservative `Refs` → `Closes` eligibility rules per story.
- Resolves canonical review contracts through `closingIssuesReferences` at the remote head.
- Documents the contract and regression coverage.

## Testing

- `node --test tests/*.test.mjs` — 26 passing
- `claude plugin validate .` and `.claude-plugin/plugin.json`
- Clean Codex marketplace/plugin installation

## Risks

None known.

## Review Guidance

- Inspect the conservative close decision and deterministic #17 fallback boundary.