### PR TITLE
feat(pr-review): add deterministic spec resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,14 @@ installations, GraphQL is a fallback only for the missing hierarchy operation.
     conditional Mermaid diagrams, then connects context, Issue–Spec traceability, summary, testing,
     risks, and review guidance. `Refs #N` is the safe default; `Closes #N` is reserved for a
     verifiably complete `type:story` contract.
-  - *pr-review* — reviews a GitHub pull request against its linked approved technical contract:
-    exactly one approved spec whose optional Issue # matches a PR closing Issue is selected through
-    `closingIssuesReferences` at the remote head. Missing or ambiguous associations remain delegated
-    to #17. It posts deduplicated right-side findings and maintains a canonical tagged review summary.
-    It uses the current branch’s PR by default; pass a positive PR number to override it. This
-    workflow requires GitHub write access through `gh`.
+  - *pr-review* — reviews a GitHub pull request against its approved technical contract using the
+    remote `headRefOid`: a unique `closingIssuesReferences` match first, then an explicit
+    `--spec <NNN|slug>` fallback, strict branch association, and approved-spec discovery. Ambiguous
+    branch or discovery results pause for a path/Issue selection before any write. With no approved
+    spec, it can perform an explicitly accepted limited review (`Spec: none`; no contractual
+    verdict). It posts deduplicated right-side findings and maintains a canonical tagged review
+    summary. It uses the current branch’s PR by default; pass a positive PR number and optionally
+    `--spec <NNN|slug>` as a fallback. This workflow requires GitHub write access through `gh`.
   - *issue-management*, *refine-issues*, *roadmap-planning* — GitHub Issues workflows for native
     milestone → epic → story planning, raw issue refinement, and progress reporting. Remote writes
     are always proposal-first and confirmation-gated.
@@ -135,8 +137,8 @@ installations, GraphQL is a fallback only for the missing hierarchy operation.
   - *repo-explorer*, *code-reviewer*, *dep-auditor* — portable skill equivalents of the Claude
     subagents.
 - **Slash commands:** `/plus-ultra:spec` — list specs, create the next-numbered spec, or flip a
-  spec's status; `/plus-ultra:pr-review [pr-number]` — publish and maintain a spec-driven PR
-  review; `/plus-ultra:issue-management`, `/plus-ultra:refine-issues <issue-number>`, and
+  spec's status; `/plus-ultra:pr-review [pr-number] [--spec <NNN|slug>]` — publish and maintain a
+  spec-driven PR review; `/plus-ultra:issue-management`, `/plus-ultra:refine-issues <issue-number>`, and
   `/plus-ultra:roadmap-planning <brief | issue-number>` — manage GitHub Issue roadmaps. Claude Code
   only; Codex uses the corresponding portable skills instead.
 - **Guardrail hooks:**

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -6,11 +6,16 @@ model: sonnet
 ---
 
 You are the GitHub PR reviewer. Follow the portable `plus-ultra:pr-review` skill exactly. Validate
-the optional PR number, GitHub authentication/write access, and PR metadata (including
-`closingIssuesReferences`) before any write. Obtain closing Issues with `gh pr view <pr-number>
---json closingIssuesReferences`; do not parse a closing keyword or use GraphQL to discover them. At
-the remote PR head, select exactly one approved technical contract whose `issue:` matches a closing
-Issue. Exclude draft and superseded specs; never substitute a sole unlinked approved spec. If the
-canonical match is missing or ambiguous, list every approved candidate, delegate fallback resolution
-to #17, and stop before writes. Use `gh` only as specified by that skill; preserve other reviewers’
-threads and report every mutation or skip.
+only its four accepted invocation forms, GitHub authentication/write access, and PR metadata
+(including `closingIssuesReferences`) before any write. Obtain closing Issues with `gh pr view
+<pr-number> --json closingIssuesReferences`; do not parse a closing keyword or use GraphQL to
+discover them. Treat the remote `headRefOid` as the source of truth for every spec read and review.
+
+Use the deterministic precedence: canonical approved closing Issue match, explicit `--spec`
+fallback, strict `headRefName` association, then all-approved-spec discovery. The explicit selector
+never overrides a canonical match. Retain approved unlinked specs as fallbacks, exclude draft and
+superseded specs, and pause for a path/Issue-ordered selection before writes whenever branch or
+discovery finds several candidates. If no approved spec exists, offer a limited review and require
+explicit acceptance; publish `Spec: none` with `limited review; no contractual verdict`, never
+evaluate acceptance criteria or emit `ready`. Use `gh` only as specified by that skill; preserve
+other reviewers’ threads and report every mutation or skip.

--- a/commands/pr-review.md
+++ b/commands/pr-review.md
@@ -1,13 +1,14 @@
 ---
 description: Review a GitHub pull request against an approved technical contract and publish maintained review findings.
-argument-hint: "[pr-number]"
+argument-hint: "[pr-number] [--spec <NNN|slug>]"
 ---
 
 Arguments: `$ARGUMENTS`
 
-Accept no argument, which reviews the PR for the current branch, or one positive integer PR number.
-If the argument is zero, negative, non-numeric, or there is more than one argument, explain the
-valid forms and stop without performing any GitHub write.
+Accept only these forms: `pr-review`, `pr-review <PR>`, `pr-review --spec <NNN|slug>`, and
+`pr-review <PR> --spec <NNN|slug>`. `<PR>` is a positive integer. Reject unknown flags, duplicate
+or missing `--spec` values, zero, negative, non-numeric, and extra positional arguments before any
+GitHub write. The selector is only a fallback when canonical closing-Issue resolution fails.
 
 Delegate the review to the `plus-ultra:pr-reviewer` agent. It must follow the portable
 `plus-ultra:pr-review` workflow, including its validation and comment-maintenance rules.

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -9,43 +9,104 @@ Review one pull request rigorously, publish durable findings, and keep only stil
 open. This is a writing workflow: it needs authenticated GitHub write access. Use
 `plus-ultra:code-reviewer` instead when a read-only current-branch review is wanted.
 
-## Preconditions and target
+## Invocation and preconditions
 
-1. Accept no argument or one **positive PR number**. With no argument, use the PR for the current
-   branch. Reject zero, negative, non-integer, or extra arguments before any write.
-2. Run `gh auth status`; stop before writes if authentication or GitHub write authorization is not
+Accept only these forms:
+
+```text
+pr-review
+pr-review <PR>
+pr-review --spec <NNN|slug>
+pr-review <PR> --spec <NNN|slug>
+```
+
+`<PR>` is one positive decimal integer. Parse arguments before any network write: reject an unknown
+flag, a duplicate `--spec`, a missing selector value, a zero, negative, or non-integer PR number,
+or any extra positional argument. Explain the valid forms and stop without a GitHub write.
+
+1. Run `gh auth status`; stop before writes if authentication or GitHub write authorization is not
    available.
-3. Resolve and validate the PR with `gh pr view <number>` (or `gh pr view` for no argument). First
-   obtain closing Issues with `gh pr view <pr-number> --json closingIssuesReferences`; fetch its
-   number, base ref, head ref, head repository, state, URL, and `headRefOid` in the same or a
-   subsequent PR-metadata request. Stop before writes if the PR cannot be found, is closed, or is
-   not reviewable. Do not parse a closing keyword from the PR body. Do not use GraphQL to discover
+2. Resolve and validate the PR with `gh pr view <number>` (or `gh pr view` with no PR argument).
+   Obtain closing Issues with `gh pr view <pr-number> --json closingIssuesReferences`; obtain the
+   number, base ref, `baseRefOid`, `headRefName`, head repository, state, URL, and `headRefOid` in the same or a
+   subsequent metadata request. Stop before writes if the PR cannot be found, is closed, or is not
+   reviewable. Do not parse a closing keyword from the PR body. Do not use GraphQL to discover
    closing Issues.
-4. From the **remote PR head**, list `specs/` and fetch each candidate spec through the GitHub API
-   at `headRefOid`; do not read the local checkout as the source of truth. For every closing Issue,
-   collect only approved specs (`status: approved`) whose `issue:` matches that Issue; exclude draft
-   and superseded specs. Select a contract only when exactly one approved spec matches the closing
-   Issues. Do not substitute an unlinked or merely sole approved spec when that canonical match is
-   missing. If zero or several candidates match, report every approved candidate and delegate the
-   missing or ambiguous resolution fallback to #17; stop before any GitHub writes. Read the selected
-   approved spec's acceptance criteria, interface contracts, architecture boundaries, functional core,
-   test plan, and risks.
+3. At the remote PR head, list `specs/` and fetch every spec through the GitHub API with
+   `headRefOid`. `headRefOid` is the source of truth for contract selection and review; do not read
+   the local checkout as a substitute. Parse each file's path, `NNN-slug` stem, status, and optional
+   positive `issue:` field. Retain all approved specs, including unlinked legacy specs, and exclude
+   draft and superseded specs.
+4. Resolve a contract using the deterministic chain below. Complete every read, selection prompt,
+   and explicit acceptance before the first GitHub mutation.
 
-Do all validation and collection before the first mutation. State every stop or skip and why.
+## Resolve the review contract
+
+Apply this precedence in order. A canonical resolution wins without consulting `--spec`; an
+explicit selector is a fallback, never an override of a canonical resolution.
+
+1. **Canonical closing-Issue match.** From `closingIssuesReferences`, collect approved remote-head
+   specs whose `issue:` equals any closing Issue. If exactly one approved spec matches the closing
+   Issues, select it without consulting `--spec`. If zero or several match, the canonical path has
+   failed and continue.
+2. **Explicit selector.** Only after canonical failure, resolve `--spec <NNN|slug>` against the
+   remote-head specs. A number selects the one `NNN-…` path; a slug selects the one matching
+   `NNN-slug` stem. A selector that is nonexistent, ambiguous, or resolves to any non-approved
+   status—including missing, malformed, unknown, draft, or superseded—is fail-closed: explain why
+   and stop without any GitHub write. A unique approved selection becomes the contract. If no
+   selector was provided, continue.
+3. **Branch association.** Match approved remote-head candidates against `headRefName` using both
+   strict patterns, then union and deduplicate the direct and indirect results:
+   - A linked spec matches directly when `issue-<N>` is a hyphen-delimited token in one branch-path
+     component: `(?:^|-)issue-<N>(?:-|$)`. Do not treat `myissue-<N>`, `issue-<N>x`, or an Issue
+     number without that token as a match.
+   - Any approved spec matches indirectly only when its complete `NNN-slug` stem is an exact
+     branch-path component separated by `/`: `(?:^|/)NNN-slug(?:/|$)`. Do not use prefix, substring,
+     title, or fuzzy matching.
+   One candidate continues as the contract. With multiple candidates, display the ordered candidate
+   list described below and wait for the user's selection. With none, continue to discovery.
+4. **Approved-spec discovery.** Consider every approved remote-head spec, including legacy specs
+   without `issue:`. One candidate becomes the contract. Several candidates require the ordered
+   selection list. No approved candidates enters the no-contract flow below.
+
+For every ambiguous branch or discovery result, list candidates in ascending path order as
+`specs/<path> — Issue #<N>` or `specs/<path> — sin Issue`. Wait for an explicit selection of one
+listed approved path before writing to GitHub. If the selection is absent, invalid, ambiguous, or
+not approved, stop without writes. Never infer a choice from the selector, branch, or local files
+after displaying this list.
+
+## No-contract flow
+
+If no approved spec exists at the remote PR head, explain how to add one: create a draft with
+`plus-ultra:spec new [<slug>] --issue <positive-integer>` when relevant, complete it, and move it to
+`approved`. Offer a review without a contract and wait for explicit acceptance before writing.
+
+With that acceptance, review correctness, regressions, tests, and the applicable
+`plus-ultra:engineering-principles`; preserve the normal inline-comment, deduplication, and
+canonical-summary process. Do not evaluate acceptance criteria or issue a `ready` verdict. The
+summary must include `Spec: none` and the exact verdict `limited review; no contractual verdict`.
+Resolve an earlier tagged finding only when fresh evidence proves it fixed without relying on a
+contract; leave contract-dependent findings unresolved and explain that limitation.
 
 ## Gather review evidence
 
-1. Fetch the submitted change with `gh pr diff <pull_number>` and inspect changed files in context.
-   Use the PR base/head range when local context is useful; do not substitute the reviewer’s local
-   branch for the PR head.
+1. Fetch the submitted change at the same remote-head snapshot. Prefer the GitHub API comparison
+   `repos/<owner>/<repo>/compare/<baseRefOid>...<headRefOid>` and file contents at `headRefOid`.
+   `gh pr diff <pull_number>` is only a visual aid: after it returns, re-fetch PR metadata and use
+   its output only when `headRefOid` is unchanged, proving it is the same remote-head snapshot.
+   Re-fetch PR metadata immediately before the first mutation; if `headRefOid` changed, discard all
+   gathered evidence and restart contract resolution and review. Do not substitute the reviewer's
+   local branch for the PR head.
 2. Fetch changed-file metadata and patches through the GitHub API as needed. Keep the PR
    `headRefOid`: it is the commit SHA required for valid inline comments.
 3. Identify the authenticated reviewer (`gh api user`) and enumerate existing review threads with
    a GraphQL query. **Paginate** until all pages are read; retain thread ID, resolved state, comment
    author, body, path, line/side, and anchor where available.
-4. Read enough surrounding source, tests, and spec text to substantiate each finding. Review for
-   unmet acceptance criteria, correctness and regression risks, contracts, error handling, tests,
-   and the architecture/functional-core boundaries in `plus-ultra:engineering-principles`.
+4. With a contract, read its acceptance criteria, interface contracts, architecture boundaries,
+   functional core, test plan, and risks. Review for unmet acceptance criteria, correctness and
+   regression risks, contracts, error handling, tests, and the architecture/functional-core
+   boundaries in `plus-ultra:engineering-principles`. Without a contract, use the limited scope
+   above instead.
 
 Only report a defect with a concrete failure scenario and a precise `path:line` when one exists.
 Do not manufacture nits, repeat a finding already addressed by the PR, or treat style preference as
@@ -82,14 +143,16 @@ skip a duplicate and report the existing thread instead of creating another one.
 For a previously tagged unresolved thread, re-check the current PR head. Resolve it only when a
 fresh review proves the reported problem is fixed. Never resolve a thread merely because code near
 it changed. In addition, only resolve a tagged thread when its review comment was authored by the
-authenticated reviewer; leave other authors’ threads untouched and report that skip. Resolve with
-the GraphQL `resolveReviewThread` mutation and report the thread ID.
+authenticated reviewer; leave other authors’ threads untouched and report that skip. In a limited
+review, resolve only findings whose evidence does not depend on a contract. Resolve with the GraphQL
+`resolveReviewThread` mutation and report the thread ID.
 
 ## Publish and update the summary
 
 Build one canonical summary containing the summary marker, review scope, spec status, findings by
 severity, unanchorable findings, skipped duplicates, resolutions, and a clear verdict. A no-finding
-summary should say what was reviewed and that no substantiated blocking issues were found.
+summary should say what was reviewed and that no substantiated blocking issues were found. For a
+limited review, use `Spec: none` and `limited review; no contractual verdict` rather than `ready`.
 
 List PR issue comments through `issues/comments` (paginate if needed) and locate summary marker
 comments created by the authenticated reviewer. Update the most recently updated such summary marker
@@ -102,5 +165,5 @@ calls and report the comment ID and whether it was created or updated.
 
 Report every mutation and every skip: inline comments created, duplicate inline comments skipped,
 threads resolved or left unresolved (with reason), and the summary created or updated. Include PR
-number and URL, spec path, reviewer identity, findings with `path:line`, and the final verdict. If
+number and URL, spec path or `none`, reviewer identity, findings with `path:line`, and the final verdict. If
 preconditions fail, report the failure and confirm that no GitHub write was attempted.

--- a/specs/003-gracefully-resolve-ambiguous-pr-to-spec-association.md
+++ b/specs/003-gracefully-resolve-ambiguous-pr-to-spec-association.md
@@ -1,0 +1,101 @@
+---
+title: Gracefully resolve ambiguous PR-to-spec association
+status: approved
+issue: 17
+created: 2026-09-06
+---
+
+# 003 — Gracefully resolve ambiguous PR-to-spec association
+
+## Problem
+
+An approved spec cannot always be selected from a PR's closing Issues. Stopping there leaves useful
+reviews unpublished, while guessing from local files or loose branch text can apply the wrong
+contract.
+
+## Goals / Non-goals
+
+**Goals**
+
+- Resolve a remote-head review contract through canonical, explicit, branch, and discovery fallbacks.
+- Pause safely for human selection when more than one approved candidate remains.
+- Permit an explicitly accepted, clearly limited review when no approved contract exists.
+
+**Non-goals**
+
+- Read `Issue.linkedBranches`, infer a relationship from titles, or use fuzzy branch matching.
+- Change hooks, plugin manifests, OpenAI metadata, or `plus-ultra:code-reviewer`.
+- Change Issue #17 or epic #20 titles, bodies, labels, hierarchy, or milestones.
+
+## Acceptance criteria
+
+- [x] Only the four planned invocation forms are accepted.
+- [x] The selection order is unique `closingIssuesReferences` match, explicit selector only after
+      canonical failure, strict `headRefName` association, then approved-spec discovery.
+- [x] Every candidate is read at the remote `headRefOid`; draft and superseded specs are excluded,
+      while approved legacy specs without `issue:` remain fallback candidates.
+- [x] Review evidence is pinned to the same remote-head snapshot, and a changed `headRefOid`
+      restarts resolution before a GitHub mutation.
+- [x] Branch matching recognizes only hyphen-delimited `issue-<N>` tokens and exact
+      `/`-separated `NNN-slug` components; direct and indirect results are deduplicated.
+- [x] Ambiguity lists ordered `path — Issue #N` or `path — sin Issue` candidates and pauses before
+      any GitHub write. Invalid explicit selectors stop without writes.
+- [x] With no approved spec, an explicitly accepted limited review retains normal comment handling,
+      publishes `Spec: none`, does not assess acceptance criteria or emit `ready`, and reports
+      `limited review; no contractual verdict`.
+
+## Interface contracts
+
+```text
+pr-review
+pr-review <positive PR number>
+pr-review --spec <NNN|slug>
+pr-review <positive PR number> --spec <NNN|slug>
+```
+
+The PR metadata request includes `closingIssuesReferences`, `headRefName`, and `headRefOid`.
+Candidate choices are rendered in ascending path order as `specs/<path> — Issue #<N>` or
+`specs/<path> — sin Issue`.
+
+## Architecture boundaries
+
+`skills/pr-review/SKILL.md` owns the complete portable resolution algorithm. The Claude command and
+reviewer agent only route to and summarize that source of truth. Remote GitHub reads and writes stay
+in the workflow; the local checkout, hooks, and read-only code reviewer do not participate in PR
+contract resolution.
+
+## Functional core
+
+The resolver is a deterministic decision over immutable PR metadata and remote spec metadata:
+canonical candidates, an optional selector, direct branch candidates, indirect branch candidates,
+and all approved candidates. It produces exactly one of a selected approved spec, a selection prompt,
+a fail-closed error, or an offered no-contract review. GitHub mutations occur only after that result
+is accepted.
+
+## Data model
+
+```yaml
+status: approved
+issue: 17 # optional; absent for legacy fallback specs
+```
+
+```text
+headRefName: feature/issue-17/003-gracefully-resolve-ambiguous-pr-to-spec-association
+headRefOid: <remote commit SHA>
+```
+
+## Test plan
+
+- Test the four valid invocations and invalid argument rejection.
+- Test canonical → explicit → branch → discovery precedence, strict branch patterns, ambiguity,
+  legacy inclusion, and draft/superseded exclusion.
+- Test remote `headRefOid` source-of-truth wording, fail-closed selectors, pre-write pauses, and the
+  limited-review summary and verdict.
+- Run the Node suite, `git diff --check`, Claude validation, and clean Codex marketplace install.
+
+## Risks
+
+- A stale or local spec could produce a wrong review; reading only `headRefOid` prevents this.
+- A permissive branch match could select an unrelated contract; exact component patterns avoid it.
+- A limited review could be mistaken for contractual approval; the required `Spec: none` and fixed
+  no-contract verdict make that boundary explicit.

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -403,8 +403,8 @@ test("pr-review workflow is packaged, safe, and available through Claude", () =>
   assert.equal(frontmatter.name, "pr-review");
   assert.match(frontmatter.description, /Use when/i);
   assert.match(frontmatter.description, /pull request|PR|GitHub/i);
-  assert.match(skill, /no argument/i);
-  assert.match(skill, /positive PR number/i);
+  assert.match(skill, /no PR argument/i);
+  assert.match(skill, /positive decimal integer/i);
   assert.match(skill, /gh auth status/i);
   assert.match(skill, /gh pr view/i);
   assert.match(skill, /gh pr diff/i);
@@ -417,11 +417,10 @@ test("pr-review workflow is packaged, safe, and available through Claude", () =>
   assert.match(skill, /exactly one approved spec matches[\s\S]*?closing\s+Issues/i);
   assert.match(skill, /Do not parse.*?closing keyword/i);
   assert.match(skill, /Do not use GraphQL.*?discover\s+closing Issues/i);
-  assert.match(skill, /delegate[\s\S]*?#17/i);
+  assert.match(skill, /explicit.*?selector.*?fallback/i);
   const normalizedReview = skill.replace(/\s+/g, " ");
   assert.match(normalizedReview, /before writes if.*ambiguous|ambiguous.*before writes/i);
-  assert.match(normalizedReview, /zero or several candidates match/i);
-  assert.match(normalizedReview, /zero or several candidates match.*?stop before any GitHub writes/i);
+  assert.match(normalizedReview, /If zero or several match.*?continue/i);
   assert.doesNotMatch(skill, /status: in-progress/);
   assert.match(codeReviewer, /status: approved/);
   assert.match(codeReviewer, /explicitly select|ask.*select/i);
@@ -439,15 +438,15 @@ test("pr-review workflow is packaged, safe, and available through Claude", () =>
   assert.match(skill, /unanchorable/i);
   assert.match(skill, /Report every mutation/i);
 
-  assert.match(command, /argument-hint: "\[pr-number\]"/);
+  assert.match(command, /argument-hint: "\[pr-number\] \[--spec <NNN\|slug>\]"/);
   assert.match(command, /positive integer/i);
   assert.match(command, /plus-ultra:pr-reviewer/);
   assert.match(agent, /^name: pr-reviewer$/m);
   assert.match(agent, /^tools: .*Bash/m);
   assert.match(agent, /plus-ultra:pr-review/);
-  assert.match(agent, /exactly one approved[\s\S]*?closing\s+Issue/i);
+  assert.match(agent, /canonical.*?closing Issue/i);
   assert.match(agent, /Do not parse.*?closing keyword/i);
-  assert.match(agent, /#17/);
+  assert.match(agent, /headRefOid/);
 
   assert.match(readme, /plus-ultra:pr-review/);
   assert.match(readme, /\/plus-ultra:pr-review \[pr-number\]/);
@@ -456,6 +455,71 @@ test("pr-review workflow is packaged, safe, and available through Claude", () =>
 
   assert.doesNotMatch(codeReviewer, /\bgh\b/i);
   assert.match(codeReviewer, /Do not modify files/i);
+});
+
+test("pr-review resolves an approved contract deterministically and can publish a limited review", () => {
+  const skill = readRelative("skills/pr-review/SKILL.md");
+  const command = readRelative("commands/pr-review.md");
+  const agent = readRelative("agents/pr-reviewer.md");
+  const readme = readRelative("README.md");
+  const spec = readRelative("specs/003-gracefully-resolve-ambiguous-pr-to-spec-association.md");
+  const commandFrontmatter = parseFrontmatter(command);
+  const normalizedSkill = skill.replace(/\s+/g, " ");
+
+  assert.equal(commandFrontmatter["argument-hint"], "[pr-number] [--spec <NNN|slug>]");
+  for (const invocation of [
+    "pr-review",
+    "pr-review <PR>",
+    "pr-review --spec <NNN|slug>",
+    "pr-review <PR> --spec <NNN|slug>",
+  ]) {
+    assert.match(command, new RegExp(invocation.replace(/[|<>]/g, "\\$&")));
+  }
+  assert.match(normalizedSkill, /only.*?pr-review.*?pr-review <PR>.*?pr-review --spec <NNN\|slug>.*?pr-review <PR> --spec <NNN\|slug>/i);
+  assert.match(normalizedSkill, /reject.*?unknown flag/i);
+  assert.match(normalizedSkill, /duplicate.*?--spec/i);
+  assert.match(normalizedSkill, /zero.*?negative.*?non-integer/i);
+  assert.match(normalizedSkill, /before any network write/i);
+
+  const canonicalIndex = normalizedSkill.indexOf("Canonical closing-Issue match");
+  const explicitIndex = normalizedSkill.indexOf("Explicit selector");
+  const branchIndex = normalizedSkill.indexOf("Branch association");
+  const discoveryIndex = normalizedSkill.indexOf("Approved-spec discovery");
+  assert.ok(canonicalIndex < explicitIndex && explicitIndex < branchIndex && branchIndex < discoveryIndex);
+  assert.match(normalizedSkill, /canonical.*?exactly one.*?select.*?without consulting.*?--spec/i);
+  assert.match(normalizedSkill, /explicit.*?fallback.*?never.*?override.*?canonical/i);
+  assert.match(normalizedSkill, /headRefOid.*?source of truth|source of truth.*?headRefOid/i);
+  assert.match(normalizedSkill, /not.*?local checkout|local checkout.*?not/i);
+  assert.match(normalizedSkill, /gh pr diff.*?headRefOid.*?same remote-head snapshot/i);
+  assert.match(normalizedSkill, /issue-<N>.*?hyphen.*?component/i);
+  assert.match(normalizedSkill, /NNN-slug.*?exact.*?component.*?\//i);
+  assert.match(normalizedSkill, /union.*?deduplicat.*?direct.*?indirect/i);
+  assert.match(normalizedSkill, /one candidate.*?continue.*?multiple.*?selection.*?none.*?discovery/i);
+  assert.match(normalizedSkill, /path.*?Issue #<N>.*?sin Issue.*?before.*?writ/i);
+  assert.match(normalizedSkill, /approved.*?unlinked.*?legacy/i);
+  assert.match(normalizedSkill, /exclude.*?draft.*?superseded/i);
+  assert.match(normalizedSkill, /selector.*?nonexistent.*?ambiguous.*?draft.*?superseded.*?fail-closed/i);
+  assert.match(normalizedSkill, /selector.*?stop without any GitHub write/i);
+  assert.match(normalizedSkill, /selector.*?non-approved.*?missing.*?malformed.*?unknown.*?stop.*?without.*?write/i);
+
+  assert.match(normalizedSkill, /no approved spec.*?review without (?:a )?contract.*?explicit acceptance/i);
+  assert.match(normalizedSkill, /correctness.*?regressions.*?tests.*?engineering[- ]principles/i);
+  assert.match(normalizedSkill, /Spec: none/);
+  assert.match(normalizedSkill, /limited review; no contractual verdict/i);
+  assert.match(normalizedSkill, /do not.*?acceptance criteria.*?do not.*?ready/i);
+  assert.match(normalizedSkill, /only.*?resolve.*?evidence.*?does not depend.*?contract/i);
+
+  assert.match(spec, /^status: approved$/m);
+  assert.match(spec, /^issue: 17$/m);
+  assert.match(spec, /closingIssuesReferences/);
+  assert.match(spec, /headRefOid/);
+  assert.match(agent, /headRefOid/);
+  assert.match(agent, /limited review|without contract/i);
+  assert.match(readme, /--spec <NNN\|slug>/);
+  assert.match(readme, /fallback/i);
+  for (const path of ["skills/pr-review/SKILL.md", "agents/pr-reviewer.md", "README.md"]) {
+    assert.doesNotMatch(readRelative(path), /delegate.*?#17|#17.*?delegate/i, `${path} has no pending #17 delegation`);
+  }
 });
 
 test("GitHub Issues workflows are portable, confirmation-gated, and available through Claude", () => {


### PR DESCRIPTION
## At a glance
Makes `pr-review` resolve its approved contract deterministically from the remote PR head, pause on ambiguity, and offer an explicitly accepted limited review when no contract exists.

## Traceability
- Issue: #17
- Spec: `specs/003-gracefully-resolve-ambiguous-pr-to-spec-association.md` (approved)
- Refs #17

## Summary
- Adds canonical, explicit-selector, strict branch, and approved-spec discovery fallbacks.
- Pins review evidence to `headRefOid` and keeps invalid selectors fail-closed.

## Testing
- `node --test tests/*.test.mjs`

## Risks
- None known.

## Review Guidance
- Check the precedence and pre-write pause rules in `skills/pr-review/SKILL.md`.