### PR TITLE
feat(release): validate plugin packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: Validate plugin
+
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: node --test tests/*.test.mjs
+      - run: node scripts/validate-packaging.mjs
+      - run: npm install --global @anthropic-ai/claude-code@2.1.236
+      - run: claude plugin validate .

--- a/scripts/validate-packaging.mjs
+++ b/scripts/validate-packaging.mjs
@@ -1,0 +1,176 @@
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { isAbsolute, relative, resolve } from "node:path";
+
+const manifestPaths = [
+  ".claude-plugin/plugin.json",
+  ".codex-plugin/plugin.json",
+  ".cursor-plugin/plugin.json",
+];
+
+const semverPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function errorPath(path, message) {
+  return `${path}: ${message}`;
+}
+
+function readJson(root, path, errors) {
+  const target = resolve(root, path);
+  if (!existsSync(target)) {
+    errors.push(errorPath(path, "missing required file"));
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(readFileSync(target, "utf8"));
+  } catch {
+    errors.push(errorPath(path, "invalid JSON"));
+    return undefined;
+  }
+}
+
+function validatePath(root, rootRealpath, source, label, errors) {
+  if (typeof source !== "string" || source.length === 0) {
+    errors.push(`${label} must be a non-empty string`);
+    return;
+  }
+  if (isAbsolute(source)) {
+    errors.push(`${label} must be relative`);
+    return;
+  }
+
+  const target = resolve(root, source);
+  if (relative(root, target).startsWith("..")) {
+    errors.push(`${label} must not escape the plugin root`);
+    return;
+  }
+  if (!existsSync(target)) {
+    errors.push(`${label} must exist`);
+    return;
+  }
+
+  const targetRealpath = realpathSync(target);
+  if (relative(rootRealpath, targetRealpath).startsWith("..")) {
+    errors.push(`${label} must not escape the plugin root`);
+  }
+}
+
+function validateManifest(root, rootRealpath, path, manifest, errors) {
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) return;
+  if (manifest.name !== "plus-ultra") {
+    errors.push(errorPath(path, 'name must be "plus-ultra"'));
+  }
+  if (typeof manifest.version !== "string" || !semverPattern.test(manifest.version)) {
+    errors.push(errorPath(path, "version must be valid SemVer"));
+  }
+  if (typeof manifest.version === "string" && /\+codex\.local-/.test(manifest.version)) {
+    errors.push(errorPath(path, "version must not use +codex.local- in a versioned manifest"));
+  }
+
+  if (path === ".claude-plugin/plugin.json") {
+    validatePath(root, rootRealpath, manifest.hooks, `${path} hooks`, errors);
+    if (!Array.isArray(manifest.dependencies) || !manifest.dependencies.includes("superpowers")) {
+      errors.push(errorPath(path, 'dependencies must include "superpowers"'));
+    }
+  }
+  if (path === ".codex-plugin/plugin.json") {
+    validatePath(root, rootRealpath, manifest.skills, `${path} skills`, errors);
+    validatePath(root, rootRealpath, manifest.hooks, `${path} hooks`, errors);
+  }
+  if (path === ".cursor-plugin/plugin.json") {
+    validatePath(root, rootRealpath, manifest.skills, `${path} skills`, errors);
+  }
+}
+
+function validateMarketplace(root, rootRealpath, path, marketplace, errors) {
+  if (!marketplace || typeof marketplace !== "object" || Array.isArray(marketplace)) return;
+  if (path === ".claude-plugin/marketplace.json" && marketplace.name !== "plus-ultra") {
+    errors.push(errorPath(path, 'name must be "plus-ultra"'));
+  }
+  if (
+    path === ".agents/plugins/marketplace.json" &&
+    !["plus-ultra", "plus-ultra-dev"].includes(marketplace.name)
+  ) {
+    errors.push(errorPath(path, 'name must be "plus-ultra" or "plus-ultra-dev"'));
+  }
+  if (!Array.isArray(marketplace.plugins)) {
+    errors.push(errorPath(path, "plugins must be an array"));
+    return;
+  }
+  const plugin = marketplace.plugins.find((entry) => entry?.name === "plus-ultra");
+  if (!plugin) {
+    errors.push(errorPath(path, 'plugins must include "plus-ultra"'));
+    return;
+  }
+  const source = typeof plugin.source === "string" ? plugin.source : plugin.source?.url;
+  validatePath(root, rootRealpath, source, `${path} plus-ultra source`, errors);
+}
+
+function validateVersionCarriers(root, version, errors) {
+  const versionFile = resolve(root, "version.txt");
+  if (existsSync(versionFile) && readFileSync(versionFile, "utf8").trim() !== version) {
+    errors.push("version.txt must match plugin manifests");
+  }
+
+  const releaseManifestPath = resolve(root, ".release-please-manifest.json");
+  const releaseManifest = existsSync(releaseManifestPath)
+    ? readJson(root, ".release-please-manifest.json", errors)
+    : undefined;
+  if (releaseManifest && releaseManifest["."] !== version) {
+    errors.push('.release-please-manifest.json "." must match plugin manifests');
+  }
+}
+
+export function validatePackaging(root) {
+  const errors = [];
+  const projectRoot = resolve(root);
+  if (!existsSync(projectRoot)) return [`plugin root does not exist: ${projectRoot}`];
+  const rootRealpath = realpathSync(projectRoot);
+  const manifests = new Map();
+
+  for (const path of manifestPaths) {
+    manifests.set(path, readJson(projectRoot, path, errors));
+  }
+  const marketplaces = new Map([
+    [
+      ".claude-plugin/marketplace.json",
+      readJson(projectRoot, ".claude-plugin/marketplace.json", errors),
+    ],
+    [
+      ".agents/plugins/marketplace.json",
+      readJson(projectRoot, ".agents/plugins/marketplace.json", errors),
+    ],
+  ]);
+
+  for (const [path, manifest] of manifests) {
+    validateManifest(projectRoot, rootRealpath, path, manifest, errors);
+  }
+  for (const [path, marketplace] of marketplaces) {
+    validateMarketplace(projectRoot, rootRealpath, path, marketplace, errors);
+  }
+
+  const versions = manifestPaths
+    .map((path) => manifests.get(path)?.version)
+    .filter((version) => typeof version === "string");
+  if (new Set(versions).size > 1) errors.push("plugin manifest versions must match");
+  if (versions.length === manifestPaths.length && new Set(versions).size === 1) {
+    validateVersionCarriers(projectRoot, versions[0], errors);
+  }
+
+  return [...new Set(errors)].sort();
+}
+
+export function runValidation(root) {
+  const errors = validatePackaging(root);
+  if (errors.length === 0) {
+    process.stdout.write("Packaging validation passed.\n");
+    return 0;
+  }
+  process.stderr.write(`Packaging validation failed:\n${errors.map((error) => `- ${error}`).join("\n")}\n`);
+  return 1;
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+if (process.argv[1] && resolve(process.argv[1]) === currentFile) {
+  process.exitCode = runValidation(process.argv[2] ?? process.cwd());
+}

--- a/specs/004-validate-plugin-packaging.md
+++ b/specs/004-validate-plugin-packaging.md
@@ -1,0 +1,77 @@
+---
+title: Validate plugin packaging
+status: approved
+issue: 42
+created: 2026-09-06
+---
+
+# 004 — Validate plugin packaging
+
+## Problem
+
+The three agent manifests and marketplace metadata can drift independently. A malformed manifest,
+portable-path violation, or accidental local dogfooding version would only be discovered after an
+installation attempt.
+
+## Goals / Non-goals
+
+**Goals**
+
+- Validate the versioned plugin package without dependencies.
+- Reject invalid JSON, inconsistent metadata and versions, non-portable paths, and local Codex
+  suffixes in source manifests.
+- Reuse the validator from CI and later release tooling.
+
+**Non-goals**
+
+- Add a package manager manifest, npm publication, or release behavior.
+- Install or mutate any local plugin marketplace.
+
+## Acceptance criteria
+
+- [x] `node scripts/validate-packaging.mjs` produces deterministic output and exits 1 for invalid
+      JSON, invalid/inconsistent metadata, divergent versions, local Codex suffixes, or invalid
+      plugin paths.
+- [x] All skills, hooks, and marketplace source paths are relative, contained by the plugin root,
+      and exist.
+- [x] When present, `version.txt` and `.release-please-manifest.json` match the manifest version.
+- [x] Node tests cover valid metadata plus version, JSON, local-suffix, path, and release-carrier
+      failures.
+- [x] Pull requests run the Node test suite, package validation, and Claude marketplace validation
+      on Node 24 through a reusable workflow.
+
+## Interface contracts
+
+```text
+node scripts/validate-packaging.mjs [plugin-root]
+```
+
+The command defaults to the current directory. It writes `Packaging validation passed.` on success;
+otherwise it writes a sorted list of validation errors to stderr and exits 1.
+
+## Architecture boundaries
+
+`scripts/validate-packaging.mjs` owns only source-package inspection. CI invokes it as an adapter;
+release and dogfooding tooling may consume its exported validation function but own their own side
+effects.
+
+## Functional core
+
+`validatePackaging(root)` derives a sorted, immutable error list from manifest content and the
+filesystem rooted at `root`. `runValidation(root)` is the narrow CLI side-effect boundary.
+
+## Data model
+
+The source of truth is the `version` field in the Claude, Codex, and Cursor plugin manifests.
+Optional release carriers use the same version string.
+
+## Test plan
+
+Use temporary package fixtures to test the CLI for success and each validation failure. Run the
+full Node suite, package validation, whitespace checks, and Claude plugin validation.
+
+## Risks
+
+Symlinks can make a textual relative path escape the package. The validator resolves existing paths
+before checking containment. A future manifest field may need explicit validation when its platform
+contract adds another plugin-relative path.

--- a/tests/packaging.test.mjs
+++ b/tests/packaging.test.mjs
@@ -1,0 +1,122 @@
+import { cpSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const repoRoot = new URL("..", import.meta.url).pathname;
+const validator = join(repoRoot, "scripts", "validate-packaging.mjs");
+
+function writeJson(root, path, value) {
+  const target = join(root, path);
+  mkdirSync(join(target, ".."), { recursive: true });
+  writeFileSync(target, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function makeFixture() {
+  const root = mkdtempSync(join(tmpdir(), "plus-ultra-packaging-"));
+  mkdirSync(join(root, "skills"), { recursive: true });
+  mkdirSync(join(root, "hooks"), { recursive: true });
+  writeFileSync(join(root, "skills", "README.md"), "skills\n");
+  writeFileSync(join(root, "hooks", "hooks.json"), "{}\n");
+  writeFileSync(join(root, "hooks", "hooks-codex.json"), "{}\n");
+
+  for (const path of [
+    ".claude-plugin/plugin.json",
+    ".codex-plugin/plugin.json",
+    ".cursor-plugin/plugin.json",
+  ]) {
+    const fields = { name: "plus-ultra", version: "0.1.0", skills: "./skills/" };
+    if (path === ".claude-plugin/plugin.json") {
+      fields.hooks = "./hooks/hooks.json";
+      fields.dependencies = ["superpowers"];
+    }
+    if (path === ".codex-plugin/plugin.json") fields.hooks = "./hooks/hooks-codex.json";
+    writeJson(root, path, fields);
+  }
+
+  writeJson(root, ".claude-plugin/marketplace.json", {
+    name: "plus-ultra",
+    plugins: [{ name: "plus-ultra", source: "./" }],
+  });
+  writeJson(root, ".agents/plugins/marketplace.json", {
+    name: "plus-ultra-dev",
+    plugins: [{ name: "plus-ultra", source: { source: "url", url: "./" } }],
+  });
+  return root;
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [validator, root], { encoding: "utf8" });
+}
+
+test("packaging validator accepts coherent plugin metadata", () => {
+  const root = makeFixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, "Packaging validation passed.\n");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("packaging validator rejects invalid manifest JSON", () => {
+  const root = makeFixture();
+  try {
+    writeFileSync(join(root, ".cursor-plugin", "plugin.json"), "{ invalid\n");
+    const result = run(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /\.cursor-plugin\/plugin\.json: invalid JSON/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("packaging validator rejects divergent versions and local suffixes", () => {
+  const root = makeFixture();
+  try {
+    const codex = JSON.parse(readFileSync(join(root, ".codex-plugin/plugin.json"), "utf8"));
+    codex.version = "0.1.1+codex.local-20260906-010203";
+    writeJson(root, ".codex-plugin/plugin.json", codex);
+    const result = run(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /versions must match/);
+    assert.match(result.stderr, /must not use \+codex\.local-/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("packaging validator rejects missing, absolute, and escaping plugin paths", () => {
+  const root = makeFixture();
+  try {
+    const claude = JSON.parse(readFileSync(join(root, ".claude-plugin/plugin.json"), "utf8"));
+    const codex = JSON.parse(readFileSync(join(root, ".codex-plugin/plugin.json"), "utf8"));
+    codex.skills = "/tmp/skills";
+    claude.hooks = "../hooks/hooks.json";
+    writeJson(root, ".claude-plugin/plugin.json", claude);
+    writeJson(root, ".codex-plugin/plugin.json", codex);
+    const result = run(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /\.codex-plugin\/plugin\.json skills must be relative/);
+    assert.match(result.stderr, /\.claude-plugin\/plugin\.json hooks must not escape the plugin root/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("packaging validator checks release version carriers when present", () => {
+  const root = makeFixture();
+  try {
+    writeFileSync(join(root, "version.txt"), "0.1.1\n");
+    writeJson(root, ".release-please-manifest.json", { ".": "0.1.2" });
+    const result = run(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /version\.txt must match plugin manifests/);
+    assert.match(result.stderr, /\.release-please-manifest\.json \"\.\" must match plugin manifests/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Refs #41
Closes #42

## At a glance
Adds deterministic, dependency-free validation so every plugin package is structurally release-ready before automation depends on it.

## Traceability
- Issue: #42
- Spec: `specs/004-validate-plugin-packaging.md` (approved)

## Summary
- Validates manifests, marketplace entries, versions, paths, and optional release carriers.
- Adds reusable Node 24 validation for pull requests.

## Testing
- `node --test tests/*.test.mjs`
- `node scripts/validate-packaging.mjs`
- `claude plugin validate .`
- clean temporary Codex installation

## Risks
- Future agent manifest path fields need explicit validator coverage.

## Review Guidance
- Inspect containment checks in `scripts/validate-packaging.mjs` and fixture failures.