### PR TITLE
feat(codex): add local plugin dogfooding

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ for this workflow, so the marketplace UI remains the supported path.
 
 Superpowers is declared as a dependency and installed automatically from the same marketplace.
 
+### Local Codex dogfooding
+
+To exercise an unreleased working tree without changing its versioned manifests, run:
+
+```
+node scripts/codex-local.mjs refresh
+```
+
+It installs a temporary `plus-ultra-dev` marketplace from `.context/`. Open a new Codex thread
+afterward so the local plugin is loaded. Return to the released plugin with:
+
+```
+node scripts/codex-local.mjs restore
+```
+
 ## Quick start
 
 After installation, tell your coding agent which path you are taking. Superpowers supplies the core

--- a/scripts/codex-local.mjs
+++ b/scripts/codex-local.mjs
@@ -1,0 +1,281 @@
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { validatePackaging } from "./validate-packaging.mjs";
+
+const developmentMarketplace = "plus-ultra-dev";
+const stableMarketplace = "plus-ultra";
+const stableSource = "maurocicerchia/plus-ultra";
+const manifestPaths = [
+  ".claude-plugin/plugin.json",
+  ".codex-plugin/plugin.json",
+  ".cursor-plugin/plugin.json",
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function runCodex(args, { allowFailure = false } = {}) {
+  const result = spawnSync(process.env.CODEX_BIN ?? "codex", args, { encoding: "utf8" });
+  if (result.error) fail(`Could not run Codex: ${result.error.message}`);
+  if (result.status !== 0 && !allowFailure) {
+    fail(`Codex command failed: codex ${args.join(" ")}\n${result.stderr || result.stdout}`.trim());
+  }
+  return result;
+}
+
+function listMarketplaces() {
+  const result = runCodex(["plugin", "marketplace", "list", "--json"]);
+  try {
+    const payload = JSON.parse(result.stdout);
+    return Array.isArray(payload.marketplaces) ? payload.marketplaces : [];
+  } catch {
+    fail("Codex returned invalid marketplace JSON");
+  }
+}
+
+function managedStage(root) {
+  return join(root, ".context", "codex-dev-marketplace");
+}
+
+function hasManagedRoot(entry, stage) {
+  if (typeof entry?.root !== "string") return false;
+  const canonical = (path) => (existsSync(path) ? realpathSync(path) : resolve(path));
+  return canonical(entry.root) === canonical(stage);
+}
+
+function requireNoForeignDevelopmentMarketplace(marketplaces, stage) {
+  const development = marketplaces.find((entry) => entry?.name === developmentMarketplace);
+  if (development && !hasManagedRoot(development, stage)) {
+    fail(
+      `Refusing to replace ${developmentMarketplace}: it points to another plugin root (${development.root}).`
+    );
+  }
+  return development;
+}
+
+function trackedAndUnignoredPaths(root) {
+  try {
+    return execFileSync("git", ["-C", root, "ls-files", "-co", "--exclude-standard", "-z"])
+      .toString("utf8")
+      .split("\0")
+      .filter(Boolean)
+      .filter((path) => ![".git", ".context"].some((prefix) => path === prefix || path.startsWith(`${prefix}/`)));
+  } catch {
+    fail("Codex local dogfooding requires a readable Git worktree");
+  }
+}
+
+function copyGitIncludedSource(root, destination) {
+  for (const path of trackedAndUnignoredPaths(root)) {
+    const source = resolve(root, path);
+    const target = resolve(destination, path);
+    if (relative(root, source).startsWith("..") || relative(destination, target).startsWith("..")) {
+      fail(`Refusing unsafe Git path: ${path}`);
+    }
+    const stat = lstatSync(source);
+    if (!stat.isFile()) continue;
+    mkdirSync(dirname(target), { recursive: true });
+    copyFileSync(source, target);
+  }
+}
+
+function timestampFromEnvironment() {
+  const configured = process.env.PLUS_ULTRA_CODEX_LOCAL_TIMESTAMP;
+  if (configured) {
+    if (!/^\d{8}-\d{6}$/.test(configured)) fail("PLUS_ULTRA_CODEX_LOCAL_TIMESTAMP must be YYYYMMDD-HHMMSS");
+    return configured;
+  }
+  const now = new Date();
+  const pad = (value) => String(value).padStart(2, "0");
+  return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(
+    now.getMinutes()
+  )}${pad(now.getSeconds())}`;
+}
+
+function addSeconds(timestamp, seconds) {
+  const match = timestamp.match(/^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})$/);
+  const date = new Date(Date.UTC(...match.slice(1).map(Number).map((value, index) => (index === 1 ? value - 1 : value))));
+  date.setUTCSeconds(date.getUTCSeconds() + seconds);
+  const pad = (value) => String(value).padStart(2, "0");
+  return `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}-${pad(
+    date.getUTCHours()
+  )}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}`;
+}
+
+function readVersion(root) {
+  return JSON.parse(readFileSync(join(root, ".codex-plugin", "plugin.json"), "utf8")).version;
+}
+
+function uniqueLocalVersion(root, stage) {
+  const release = readVersion(root);
+  const previousManifest = join(stage, "plugins", "plus-ultra", ".codex-plugin", "plugin.json");
+  const previous = existsSync(previousManifest)
+    ? JSON.parse(readFileSync(previousManifest, "utf8")).version
+    : undefined;
+  const initialTimestamp = timestampFromEnvironment();
+  let increment = 0;
+  let version = `${release}+codex.local-${initialTimestamp}`;
+  while (version === previous) {
+    increment += 1;
+    version = `${release}+codex.local-${addSeconds(initialTimestamp, increment)}`;
+  }
+  return version;
+}
+
+function setStagedVersions(pluginRoot, version) {
+  for (const path of manifestPaths) {
+    const target = join(pluginRoot, path);
+    const manifest = JSON.parse(readFileSync(target, "utf8"));
+    manifest.version = version;
+    writeFileSync(target, `${JSON.stringify(manifest, null, 2)}\n`);
+  }
+}
+
+function writeDevelopmentMarketplace(stage) {
+  const path = join(stage, ".agents", "plugins", "marketplace.json");
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(
+    path,
+    `${JSON.stringify(
+      {
+        name: developmentMarketplace,
+        interface: { displayName: "Plus Ultra Development" },
+        plugins: [
+          {
+            name: "plus-ultra",
+            source: { source: "url", url: "./plugins/plus-ultra" },
+            policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" },
+            category: "Developer Tools",
+          },
+        ],
+      },
+      null,
+      2
+    )}\n`
+  );
+}
+
+function initializeStagedRepository(pluginRoot) {
+  try {
+    execFileSync("git", ["-C", pluginRoot, "init", "--initial-branch=main"], { stdio: "ignore" });
+    execFileSync("git", ["-C", pluginRoot, "config", "user.name", "Plus Ultra dogfooding"], { stdio: "ignore" });
+    execFileSync("git", ["-C", pluginRoot, "config", "user.email", "dogfooding@plus-ultra.local"], {
+      stdio: "ignore",
+    });
+    execFileSync("git", ["-C", pluginRoot, "add", "--all"], { stdio: "ignore" });
+    execFileSync("git", ["-C", pluginRoot, "commit", "-m", "chore: stage local plugin"], { stdio: "ignore" });
+  } catch {
+    fail("Could not initialize the staged plugin repository");
+  }
+}
+
+function buildStaging(root, stage) {
+  const parent = dirname(stage);
+  mkdirSync(parent, { recursive: true });
+  const temporary = mkdtempSync(join(parent, ".codex-dev-marketplace-"));
+  try {
+    const pluginRoot = join(temporary, "plugins", "plus-ultra");
+    copyGitIncludedSource(root, pluginRoot);
+    setStagedVersions(pluginRoot, uniqueLocalVersion(root, stage));
+    initializeStagedRepository(pluginRoot);
+    writeDevelopmentMarketplace(temporary);
+    return temporary;
+  } catch (error) {
+    rmSync(temporary, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function replaceStaging(stage, temporary) {
+  const backup = `${stage}.backup-${process.pid}`;
+  if (existsSync(backup)) rmSync(backup, { recursive: true, force: true });
+  if (existsSync(stage)) renameSync(stage, backup);
+  renameSync(temporary, stage);
+  return backup;
+}
+
+export function refresh(root = process.cwd()) {
+  const source = resolve(root);
+  const errors = validatePackaging(source);
+  if (errors.length > 0) fail(`Source packaging is invalid:\n${errors.map((error) => `- ${error}`).join("\n")}`);
+
+  const stage = managedStage(source);
+  const marketplaces = listMarketplaces();
+  const development = requireNoForeignDevelopmentMarketplace(marketplaces, stage);
+  const temporary = buildStaging(source, stage);
+  const backup = replaceStaging(stage, temporary);
+  try {
+    if (development) {
+      runCodex(["plugin", "remove", `plus-ultra@${developmentMarketplace}`], { allowFailure: true });
+      runCodex(["plugin", "marketplace", "remove", developmentMarketplace]);
+    }
+    runCodex(["plugin", "remove", `plus-ultra@${stableMarketplace}`], { allowFailure: true });
+    runCodex(["plugin", "marketplace", "add", stage]);
+    runCodex(["plugin", "add", `plus-ultra@${developmentMarketplace}`]);
+    rmSync(backup, { recursive: true, force: true });
+  } catch (error) {
+    rmSync(stage, { recursive: true, force: true });
+    if (existsSync(backup)) renameSync(backup, stage);
+    throw error;
+  }
+  return stage;
+}
+
+export function restore(root = process.cwd()) {
+  const source = resolve(root);
+  const stage = managedStage(source);
+  const marketplaces = listMarketplaces();
+  const development = requireNoForeignDevelopmentMarketplace(marketplaces, stage);
+
+  if (development) {
+    runCodex(["plugin", "remove", `plus-ultra@${developmentMarketplace}`], { allowFailure: true });
+    runCodex(["plugin", "marketplace", "remove", developmentMarketplace]);
+  }
+  if (existsSync(stage)) rmSync(stage, { recursive: true, force: true });
+
+  const stable = marketplaces.find((entry) => entry?.name === stableMarketplace);
+  if (stable) {
+    runCodex(["plugin", "marketplace", "upgrade", stableMarketplace]);
+  } else {
+    runCodex(["plugin", "marketplace", "add", stableSource, "--ref", "main"]);
+  }
+  runCodex(["plugin", "add", `plus-ultra@${stableMarketplace}`]);
+}
+
+function usage() {
+  process.stderr.write("Usage: node scripts/codex-local.mjs <refresh|restore>\n");
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+if (process.argv[1] && resolve(process.argv[1]) === currentFile) {
+  try {
+    const action = process.argv[2];
+    if (action === "refresh") {
+      const stage = refresh();
+      process.stdout.write(`Installed local Plus Ultra from ${stage}. Open a new Codex thread to load it.\n`);
+    } else if (action === "restore") {
+      restore();
+      process.stdout.write("Restored stable Plus Ultra. Open a new Codex thread to load it.\n");
+    } else {
+      usage();
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/specs/006-codex-local-dogfooding.md
+++ b/specs/006-codex-local-dogfooding.md
@@ -1,0 +1,83 @@
+---
+title: Codex local dogfooding
+status: approved
+issue: 44
+created: 2026-09-06
+---
+
+# 006 — Codex local dogfooding
+
+## Problem
+
+Codex developers need to test unreleased Plus Ultra changes, but altering versioned manifests for a
+local install would create an accidental release mismatch and pollute the working tree.
+
+## Goals / Non-goals
+
+**Goals**
+
+- Stage a Git-included source snapshot under `.context/` with a unique local-only SemVer build
+  suffix.
+- Switch Codex between the local development marketplace and the stable marketplace safely.
+- Preserve every versioned source manifest throughout refresh and restore.
+
+**Non-goals**
+
+- Publish a local snapshot, alter a release version, or support arbitrary marketplace names.
+- Delete a development marketplace that does not point to this script's managed staging root.
+
+## Acceptance criteria
+
+- [x] `node scripts/codex-local.mjs refresh` validates source packaging before staging and creates
+      `<release>+codex.local-YYYYMMDD-HHMMSS` versions only in the copied manifests.
+- [x] Staging includes only tracked or unignored untracked files and excludes `.git`, `.context`,
+      and ignored secrets.
+- [x] Staging is completed in a temporary directory before replacement; a foreign
+      `plus-ultra-dev` marketplace stops with no deletion.
+- [x] Refresh removes the stable installation, installs the local `plus-ultra-dev` marketplace,
+      and tells the developer to open a new thread.
+- [x] `restore` removes only the managed local marketplace/staging, updates or adds stable
+      marketplace metadata, reinstalls `plus-ultra@plus-ultra`, and tells the developer to open a
+      new thread.
+- [x] Temporary Git fixtures and a fake Codex executable verify safe copy, suffix uniqueness,
+      repeated refresh, command ordering, conflict handling, restore, and a clean source tree.
+
+## Interface contracts
+
+```text
+node scripts/codex-local.mjs refresh
+node scripts/codex-local.mjs restore
+```
+
+The managed staging root is `.context/codex-dev-marketplace`. `refresh` exposes it as marketplace
+`plus-ultra-dev`; `restore` returns the installation to `plus-ultra`.
+
+## Architecture boundaries
+
+The package validator guards source input. `codex-local.mjs` owns Git snapshotting, local staging,
+and Codex CLI orchestration. The Codex CLI is the external side-effect boundary, isolated behind
+one command runner.
+
+## Functional core
+
+Git's `ls-files -co --exclude-standard` determines an immutable copy set. Version derivation,
+managed-root comparison, and local marketplace JSON construction are deterministic from explicit
+inputs; filesystem replacement and Codex commands are side effects.
+
+## Data model
+
+The source version remains `X.Y.Z`. Staged copies use `X.Y.Z+codex.local-YYYYMMDD-HHMMSS`. The
+development marketplace points only at `./plugins/plus-ultra` within the managed staging root.
+
+## Test plan
+
+Create temporary Git repositories plus a fake `codex` executable. Assert source-copy selection,
+ignored-secret exclusion, all staged suffixes, repeat uniqueness, command sequence, conflict abort,
+restore behavior, and unchanged source manifests. Run refresh/restore with a temporary `CODEX_HOME`
+and confirm a source manifest diff remains empty.
+
+## Risks
+
+An interrupted Codex operation can leave a local marketplace installed, but source manifests stay
+unchanged and `restore` provides an explicit recovery path. A development marketplace owned by
+another root is never removed automatically.

--- a/tests/codex-local.test.mjs
+++ b/tests/codex-local.test.mjs
@@ -1,0 +1,197 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const repoRoot = new URL("..", import.meta.url).pathname;
+const command = join(repoRoot, "scripts", "codex-local.mjs");
+
+function writeJson(root, path, value) {
+  const target = join(root, path);
+  mkdirSync(join(target, ".."), { recursive: true });
+  writeFileSync(target, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function run(command, args, cwd) {
+  execFileSync(command, args, { cwd, stdio: "ignore" });
+}
+
+function makeSource() {
+  const root = join(tmpdir(), `plus-ultra-codex-local-${process.pid}-${Math.random()}`);
+  mkdirSync(root, { recursive: true });
+  mkdirSync(join(root, "skills"), { recursive: true });
+  mkdirSync(join(root, "hooks"), { recursive: true });
+  writeFileSync(join(root, "skills", "README.md"), "skills\n");
+  writeFileSync(join(root, "hooks", "hooks.json"), "{}\n");
+  writeFileSync(join(root, "hooks", "hooks-codex.json"), "{}\n");
+  writeFileSync(join(root, ".gitignore"), ".env\n.context/\n");
+  writeFileSync(join(root, ".env"), "SECRET=do-not-copy\n");
+  writeFileSync(join(root, "untracked.md"), "copy me\n");
+  mkdirSync(join(root, ".context"), { recursive: true });
+  writeFileSync(join(root, ".context", "private.txt"), "do-not-copy\n");
+
+  for (const path of [
+    ".claude-plugin/plugin.json",
+    ".codex-plugin/plugin.json",
+    ".cursor-plugin/plugin.json",
+  ]) {
+    const manifest = { name: "plus-ultra", version: "0.1.0", skills: "./skills/" };
+    if (path === ".claude-plugin/plugin.json") {
+      manifest.hooks = "./hooks/hooks.json";
+      manifest.dependencies = ["superpowers"];
+    }
+    if (path === ".codex-plugin/plugin.json") manifest.hooks = "./hooks/hooks-codex.json";
+    writeJson(root, path, manifest);
+  }
+  writeJson(root, ".claude-plugin/marketplace.json", {
+    name: "plus-ultra",
+    plugins: [{ name: "plus-ultra", source: "./" }],
+  });
+  writeJson(root, ".agents/plugins/marketplace.json", {
+    name: "plus-ultra",
+    plugins: [{ name: "plus-ultra", source: { source: "url", url: "./" } }],
+  });
+  writeFileSync(join(root, "version.txt"), "0.1.0\n");
+  writeJson(root, ".release-please-manifest.json", { ".": "0.1.0" });
+
+  run("git", ["init", "--initial-branch=main"], root);
+  run("git", ["config", "user.email", "test@example.com"], root);
+  run("git", ["config", "user.name", "Codex local tests"], root);
+  run("git", ["add", "."], root);
+  run("git", ["commit", "-m", "feat: source fixture"], root);
+  return root;
+}
+
+function makeFakeCodex(root) {
+  const bin = join(root, "bin");
+  const log = join(root, "codex-commands.jsonl");
+  mkdirSync(bin, { recursive: true });
+  const script = `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(process.env.FAKE_CODEX_LOG, JSON.stringify(args) + "\\n");
+if (args.join(" ") === "plugin marketplace list --json") {
+  process.stdout.write(process.env.FAKE_MARKETPLACES ?? '{"marketplaces":[]}');
+}
+`;
+  writeFileSync(join(bin, "codex"), script);
+  chmodSync(join(bin, "codex"), 0o755);
+  return { binary: join(bin, "codex"), log };
+}
+
+function runLocal(root, fake, action, options = {}) {
+  const result = spawnSync(process.execPath, [command, action], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CODEX_BIN: fake.binary,
+      FAKE_CODEX_LOG: fake.log,
+      PLUS_ULTRA_CODEX_LOCAL_TIMESTAMP: "20260906-010203",
+      ...options.env,
+    },
+  });
+  return result;
+}
+
+function commandLog(path) {
+  return existsSync(path)
+    ? readFileSync(path, "utf8")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line))
+    : [];
+}
+
+test("refresh stages only Git-included source files with a unique local version", () => {
+  const root = makeSource();
+  const fake = makeFakeCodex(root);
+  try {
+    assert.equal(runLocal(root, fake, "refresh").status, 0);
+    const stage = join(root, ".context", "codex-dev-marketplace");
+    assert.equal(existsSync(join(stage, "plugins", "plus-ultra", ".git")), true);
+    assert.equal(readFileSync(join(stage, "plugins", "plus-ultra", "untracked.md"), "utf8"), "copy me\n");
+    assert.equal(existsSync(join(stage, "plugins", "plus-ultra", ".env")), false);
+    assert.equal(existsSync(join(stage, "plugins", "plus-ultra", ".context")), false);
+    for (const path of [
+      ".claude-plugin/plugin.json",
+      ".codex-plugin/plugin.json",
+      ".cursor-plugin/plugin.json",
+    ]) {
+      assert.match(
+        JSON.parse(readFileSync(join(stage, "plugins", "plus-ultra", path), "utf8")).version,
+        /^0\.1\.0\+codex\.local-20260906-010203$/
+      );
+      assert.equal(JSON.parse(readFileSync(join(root, path), "utf8")).version, "0.1.0");
+    }
+    assert.equal(
+      JSON.parse(readFileSync(join(stage, ".agents", "plugins", "marketplace.json"), "utf8")).name,
+      "plus-ultra-dev"
+    );
+    assert.deepEqual(commandLog(fake.log).slice(-3), [
+      ["plugin", "remove", "plus-ultra@plus-ultra"],
+      ["plugin", "marketplace", "add", realpathSync(stage)],
+      ["plugin", "add", "plus-ultra@plus-ultra-dev"],
+    ]);
+
+    assert.equal(runLocal(root, fake, "refresh").status, 0);
+    const nextVersion = JSON.parse(
+      readFileSync(join(stage, "plugins", "plus-ultra", ".codex-plugin", "plugin.json"), "utf8")
+    ).version;
+    assert.equal(nextVersion, "0.1.0+codex.local-20260906-010204");
+    run("git", ["diff", "--exit-code"], root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("refresh aborts before replacing a foreign development marketplace", () => {
+  const root = makeSource();
+  const fake = makeFakeCodex(root);
+  try {
+    const result = runLocal(root, fake, "refresh", {
+      env: {
+        FAKE_MARKETPLACES: JSON.stringify({
+          marketplaces: [{ name: "plus-ultra-dev", root: "/another/plugin/root" }],
+        }),
+      },
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /plus-ultra-dev.*another plugin root/i);
+    assert.equal(existsSync(join(root, ".context", "codex-dev-marketplace")), false);
+    assert.deepEqual(commandLog(fake.log), [["plugin", "marketplace", "list", "--json"]]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("restore removes only managed development state and reinstalls the stable plugin", () => {
+  const root = makeSource();
+  const fake = makeFakeCodex(root);
+  try {
+    assert.equal(runLocal(root, fake, "refresh").status, 0);
+    const stage = join(root, ".context", "codex-dev-marketplace");
+    writeFileSync(fake.log, "");
+    const result = runLocal(root, fake, "restore", {
+      env: {
+        FAKE_MARKETPLACES: JSON.stringify({
+          marketplaces: [{ name: "plus-ultra-dev", root: stage }],
+        }),
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(existsSync(stage), false);
+    assert.deepEqual(commandLog(fake.log), [
+      ["plugin", "marketplace", "list", "--json"],
+      ["plugin", "remove", "plus-ultra@plus-ultra-dev"],
+      ["plugin", "marketplace", "remove", "plus-ultra-dev"],
+      ["plugin", "marketplace", "add", "maurocicerchia/plus-ultra", "--ref", "main"],
+      ["plugin", "add", "plus-ultra@plus-ultra"],
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Refs #41
Closes #44

## At a glance
Adds a safe local Codex plugin workflow that stages unreleased work without modifying versioned source manifests.

## Traceability
- Issue: #44
- Spec: `specs/006-codex-local-dogfooding.md` (approved)

## Summary
- Adds `refresh` and `restore` commands backed by Git-included staging and local SemVer suffixes.
- Refuses to replace a development marketplace owned by another root.

## Testing
- `node --test tests/*.test.mjs`
- `node scripts/validate-packaging.mjs`
- `claude plugin validate .`
- real temporary-CODEX_HOME refresh

## Risks
- Stable restore is revalidated once the stable marketplace identity reaches `main`; a foreign development marketplace is intentionally left untouched.

## Review Guidance
- Inspect staging replacement/rollback and Codex command ordering in `scripts/codex-local.mjs`.