### PR TITLE
feat(pr-review): define verdict-first summary hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,9 @@ sandbox. There is no `plus-ultra:integrate` command.
     `--spec <NNN|slug>` fallback, strict branch association, and approved-spec discovery. Ambiguous
     branch or discovery results pause for a path/Issue selection before any write. With no approved
     spec, it can perform an explicitly accepted limited review (`Spec: none`; no contractual
-    verdict). It posts deduplicated right-side findings and maintains a canonical tagged review
-    summary. It uses the current branch’s PR by default; pass a positive PR number and optionally
+    verdict). It posts deduplicated right-side findings and maintains a canonical, verdict-first
+    tagged summary: a visible Ready, Changes required, or Limited review status before findings and
+    compact traceability. It uses the current branch’s PR by default; pass a positive PR number and optionally
     `--spec <NNN|slug>` as a fallback. This workflow requires GitHub write access through `gh`.
   - *integration-boundary* — portable policy for ending autonomous work at ready for integration;
     manual merge and publication remain human-owned.

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -149,10 +149,79 @@ review, resolve only findings whose evidence does not depend on a contract. Reso
 
 ## Publish and update the summary
 
-Build one canonical summary containing the summary marker, review scope, spec status, findings by
-severity, unanchorable findings, skipped duplicates, resolutions, and a clear verdict. A no-finding
-summary should say what was reviewed and that no substantiated blocking issues were found. For a
-limited review, use `Spec: none` and `limited review; no contractual verdict` rather than `ready`.
+Build one canonical summary with this verdict-first Markdown contract. The stable summary marker
+must appear once, first; do not substitute a new marker or put an emoji in the title. Copy the
+shape below, replacing placeholders and omitting the explicitly optional or empty content. The
+leading spaces on the template's lower-level headings are valid Markdown indentation and keep this
+contract within this source-of-truth section.
+
+<!-- plus-ultra:pr-review:summary -->
+# Plus Ultra PR Review
+
+ ## Status
+
+Select exactly one visible verdict:
+
+- `✅ Ready — no findings or non-blocking findings.` Use this when there are no findings, or when
+  every current finding is non-blocking.
+- `⛔ Changes required — one or more blockers.` Use this when one or more current findings block
+  the contractual review.
+- `⚠️ Limited review — Spec: none; limited review; no contractual verdict` Use this only for an
+  accepted no-contract review. It must not say `ready`.
+
+State the review scope and the basis for the selected verdict in plain language.
+
+ ## Findings
+
+When there are no current findings, write `No findings.` and say what was reviewed. Otherwise,
+group visible findings only beneath the severity headings that are present; omit every empty
+severity heading and do not add a separate unanchorable category. Each unanchorable finding remains
+visible under its applicable severity and is marked `[summary-only]`, for example:
+
+ ### <Severity>
+
+- **[summary-only] <human finding>** — <failure scenario, affected behavior, and requested fix>.
+  This finding is unanchorable and therefore summary-only.
+
+ ## Traceability
+
+| Issue | Spec | Contract |
+| --- | --- | --- |
+| #<N> | `specs/<path>` (approved) | Contractual review |
+| none | `specs/<path>` (approved) | Contractual review |
+| none | none | Limited review |
+
+Use the second row for an approved legacy contract whose frontmatter has no `issue:` field. For a
+limited review, use the third row with `none` in the Issue and Spec cells and `Limited review` in
+Contract. This keeps a no-Issue contractual review distinct from a no-contract limited review.
+
+ ## Resolutions from the previous review
+
+Include this section only when one or more prior findings were resolved. Describe each resolution
+human-first (the behavior that is now fixed and the evidence), not as an internal identifier. Keep
+thread IDs in Metadata only.
+
+ <details>
+ <summary>Evidence</summary>
+
+- Review scope, remote-head evidence, changed files, tests, and the evidence supporting each
+  visible finding or resolution.
+
+ </details>
+
+ <details>
+ <summary>Metadata</summary>
+
+- IDs are metadata-only; include them only when non-empty.
+- SHAs are metadata-only; include them only when non-empty.
+- Duplicate thread references are metadata-only; include them only when non-empty.
+- Counts are metadata-only; include them only when non-empty.
+
+ </details>
+
+Do not surface IDs, SHAs, duplicate thread references, or counts outside Metadata; omit each when
+empty. This preserves a human-readable canonical comment while retaining exceptional bookkeeping
+when it is useful.
 
 List PR issue comments through `issues/comments` (paginate if needed) and locate summary marker
 comments created by the authenticated reviewer. Update the most recently updated such summary marker

--- a/specs/008-improve-pr-review-comment-hierarchy.md
+++ b/specs/008-improve-pr-review-comment-hierarchy.md
@@ -1,0 +1,124 @@
+---
+title: Improve PR review comment hierarchy
+status: approved
+issue: 55
+created: 2026-09-07
+---
+
+# 008 — Improve PR review comment hierarchy
+
+## Problem
+
+The canonical PR-review comment currently describes its contents without a stable, human-scannable
+order. Reviewers and authors must work through findings and bookkeeping before understanding the
+review verdict, while unanchorable findings and historical resolution data have no explicit visual
+placement.
+
+## Goals / Non-goals
+
+**Goals**
+
+- Define one verdict-first Markdown contract for the canonical tagged PR-review summary.
+- Make the ready, changes-required, and limited-review states visible and unambiguous.
+- Keep current findings and prior resolutions useful to people while moving exceptional bookkeeping
+  into collapsible metadata.
+- Remain compatible with the remote-head contract resolution in approved specs 002 and 003.
+
+**Non-goals**
+
+- Change PR-review invocation, GitHub endpoints, stable markers, finding severity semantics,
+  deduplication, inline anchoring, or review-thread resolution.
+- Add a renderer, a new persisted data model, commands, hooks, manifests, or agent-specific logic.
+- Change the approved contract-selection precedence or accepted limited-review workflow from specs
+  002 and 003.
+
+## Acceptance criteria
+
+- [x] The portable PR-review skill declares a canonical summary beginning with the existing stable
+      summary marker and the exact emoji-free title `# Plus Ultra PR Review`.
+- [x] The summary displays exactly one verdict: `✅ Ready` for no findings or only non-blocking
+      findings, `⛔ Changes required` for one or more blockers, or `⚠️ Limited review` for an
+      accepted no-contract review.
+- [x] A limited review visibly includes `Spec: none` and the exact phrase `limited review; no
+      contractual verdict`, and never presents itself as ready.
+- [x] Visible findings are grouped only by severities that have findings; empty severities are
+      omitted, and unanchorable findings remain in their visible severity group as `summary-only`.
+- [x] The summary includes a compact Issue, Spec, Contract table; prior resolutions appear only
+      when present and use human-first descriptions. An approved legacy contract without `issue:`
+      renders `none`, its approved spec path, and `Contractual review`, remaining distinct from
+      the all-`none` `Limited review` row.
+- [x] Evidence and Metadata use `<details>` blocks. IDs, SHAs, duplicate-thread references, and
+      counts are metadata-only and omitted when empty.
+- [x] The canonical-comment update, deduplication, inline-comment, and thread-resolution workflows
+      remain unchanged.
+- [x] README documentation briefly describes the verdict-first review summary, and regression tests
+      validate the contract without weakening earlier review behavior.
+
+## Interface contracts
+
+The sole public interface change is the canonical Markdown body posted through the existing
+`issues/comments` workflow. It uses the existing marker and the following ordered visible shape:
+
+```markdown
+<!-- plus-ultra:pr-review:summary -->
+# Plus Ultra PR Review
+## Status
+## Findings
+| Issue | Spec | Contract |
+## Resolutions from the previous review  <!-- only when present -->
+<details><summary>Evidence</summary>...</details>
+<details><summary>Metadata</summary>...</details>
+```
+
+The existing `pr-review` invocation forms, `pulls/{pull_number}/comments` inline-comment endpoint,
+`issues/comments` canonical-summary endpoint, `resolveReviewThread` mutation, and marker strings
+remain unchanged. This is compatible with spec 002's approved Issue–Spec traceability and spec
+003's approved remote-head selection and no-contract flow.
+
+## Architecture boundaries
+
+`skills/pr-review/SKILL.md` remains the portable source of truth for comment shape and for existing
+GitHub review operations. `README.md` provides concise user-facing discovery only. The Claude-only
+command and reviewer agent, hooks, manifests, and GitHub APIs are outside this change, preserving
+the portability boundary used by specs 002 and 003.
+
+## Functional core
+
+The summary shape is a deterministic projection of an already-completed review: verdict, visible
+findings, traceability, optional resolutions, evidence, and exceptional metadata. Verdict selection
+uses existing severity and contract results: blockers select Changes required; otherwise a
+contractual review selects Ready; and the existing explicitly accepted no-contract path selects
+Limited review. GitHub reads and mutations remain adapters governed by the unchanged workflow.
+
+## Data model
+
+No persisted schema or API type changes. The canonical Markdown comment continues to carry:
+
+```text
+marker, verdict, findings, Issue/Spec/Contract traceability, optional resolutions, evidence, metadata
+```
+
+An approved legacy contract without `issue:` uses `none | specs/<path> (approved) | Contractual
+review`; the accepted no-contract path instead uses `none | none | Limited review`.
+
+Internal IDs, head SHAs, duplicate-thread references, and counts are optional metadata rather than
+visible review content.
+
+## Test plan
+
+- Verify the portable skill specifies the exact title and each verdict, including Ready with no
+  findings and with non-blocking findings, blockers requiring Changes required, and limited review
+  with `Spec: none` and the exact no-contract verdict.
+- Verify canonical ordering, present-severity-only findings, visible `summary-only` unanchorable
+  findings, conditional human-first resolutions, and bounded Evidence/Metadata bookkeeping.
+- Preserve existing tests for deterministic contract selection, remote-head evidence, canonical
+  update, deduplication, inline anchoring, and thread resolution.
+- Run `node --test tests/skills.test.mjs`, `node --test tests/*.test.mjs`, and `git diff --check`.
+
+## Risks
+
+The new template could accidentally expose implementation identifiers or imply a contractual
+approval during a no-contract review. Keeping such bookkeeping in optional Metadata and prescribing
+the limited-review phrase mitigates both risks. Changing the template without preserving its stable
+marker could create duplicate canonical comments; retaining that marker and the existing
+update-selection workflow avoids this compatibility risk.

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -29,6 +29,14 @@ function markdownSubsection(markdown, heading) {
   return nextHeading === -1 ? content : content.slice(0, nextHeading);
 }
 
+function detailsBlock(markdown, label) {
+  const match = markdown.match(
+    new RegExp(`<details>\\s*<summary>${label}</summary>[\\s\\S]*?</details>`)
+  );
+  assert.ok(match, `${label} is contained in a details block`);
+  return match[0];
+}
+
 function parseFrontmatter(markdown) {
   const match = markdown.match(/^---\n([\s\S]*?)\n---\n/);
   assert.ok(match, "skill has YAML frontmatter");
@@ -520,6 +528,186 @@ test("pr-review resolves an approved contract deterministically and can publish 
   for (const path of ["skills/pr-review/SKILL.md", "agents/pr-reviewer.md", "README.md"]) {
     assert.doesNotMatch(readRelative(path), /delegate.*?#17|#17.*?delegate/i, `${path} has no pending #17 delegation`);
   }
+});
+
+test("pr-review defines verdict semantics in its publish-and-update summary guidance", () => {
+  const contract = markdownSection(
+    readRelative("skills/pr-review/SKILL.md"),
+    "Publish and update the summary"
+  );
+  const statusStart = contract.indexOf("## Status");
+  const findingsStart = contract.indexOf("## Findings");
+
+  assert.notEqual(statusStart, -1, "Status is in the publish-and-update summary guidance");
+  assert.notEqual(findingsStart, -1, "Findings follows Status in the publish-and-update summary guidance");
+  const status = contract.slice(statusStart, findingsStart);
+
+  assert.match(status, /✅ Ready — no findings or non-blocking findings\./);
+  assert.match(status, /⛔ Changes required — one or more blockers\./);
+  assert.match(status, /⚠️ Limited review/);
+  assert.match(status, /Spec: none/);
+  assert.match(status, /limited review; no contractual verdict/);
+});
+
+test("pr-review makes its publish-and-update summary guidance complete and bounded", () => {
+  const contract = markdownSection(
+    readRelative("skills/pr-review/SKILL.md"),
+    "Publish and update the summary"
+  );
+  const marker = "<!-- plus-ultra:pr-review:summary -->";
+  const markerIndex = contract.indexOf(marker);
+  const titleIndex = contract.indexOf("# Plus Ultra PR Review");
+  const statusIndex = contract.indexOf("## Status");
+  const findingsIndex = contract.indexOf("## Findings");
+  const traceabilityIndex = contract.indexOf("| Issue | Spec | Contract |");
+  const resolutionsHeading = contract.match(/^\s*## .*resolv.*$/im);
+  const resolutionsIndex = resolutionsHeading ? contract.indexOf(resolutionsHeading[0]) : -1;
+  const evidenceIndex = contract.indexOf("<summary>Evidence</summary>");
+  const metadataIndex = contract.indexOf("<summary>Metadata</summary>");
+  const findings = contract.slice(findingsIndex, traceabilityIndex);
+  const evidence = detailsBlock(contract, "Evidence");
+  const metadata = detailsBlock(contract, "Metadata");
+
+  assert.equal(contract.split(marker).length - 1, 1, "the contract has one summary marker");
+  assert.match(contract, /^# Plus Ultra PR Review$/m);
+  assert.doesNotMatch(contract, /^# .*Plus Ultra PR Review.*[✅⛔⚠️]/m);
+  for (const [name, index] of [
+    ["summary marker", markerIndex],
+    ["title", titleIndex],
+    ["status", statusIndex],
+    ["findings", findingsIndex],
+    ["traceability table", traceabilityIndex],
+    ["evidence", evidenceIndex],
+    ["metadata", metadataIndex],
+  ]) {
+    assert.notEqual(index, -1, `${name} is present in publish-and-update summary guidance`);
+  }
+  assert.ok(
+    markerIndex < titleIndex &&
+      titleIndex < statusIndex &&
+      statusIndex < findingsIndex &&
+      findingsIndex < traceabilityIndex &&
+      traceabilityIndex < evidenceIndex &&
+      evidenceIndex < metadataIndex,
+    "publish-and-update summary guidance keeps its required order"
+  );
+
+  if (resolutionsIndex !== -1) {
+    assert.ok(
+      traceabilityIndex < resolutionsIndex && resolutionsIndex < evidenceIndex,
+      "the optional resolutions section follows traceability and precedes evidence"
+    );
+  }
+
+  assert.match(
+    findings,
+    /(?:<Severity>|severity)[\s\S]*?summary-only[\s\S]*?unanchorable/i,
+    "the visible Findings portion identifies unanchorable findings as summary-only"
+  );
+  assert.match(
+    contract.replace(/\s+/g, " "),
+    /(?:resolutions?.{0,120}(?:only if|only when|when).{0,120}(?:exist|non[- ]?empty|one or more)|(?:include|omit).{0,120}resolutions?.{0,120}(?:only if|only when|when).{0,120}(?:exist|non[- ]?empty|one or more))/i,
+    "resolutions are conditional on resolutions existing"
+  );
+  for (const field of ["IDs", "SHAs", "duplicate thread references", "counts"]) {
+    const declaration = metadata
+      .split("\n")
+      .find((line) => new RegExp(field, "i").test(line));
+    assert.ok(declaration, `${field} has a declaration in Metadata`);
+    assert.match(
+      declaration,
+      /metadata/i,
+      `${field} is identified as metadata-only`
+    );
+    assert.match(
+      declaration,
+      /(?:omit|exclude|leave out|include)[\s\S]*(?:empty|non[- ]?empty)|(?:if|when)[\s\S]*(?:empty|non[- ]?empty)/i,
+      `${field} is included only when nonempty`
+    );
+  }
+  assert.match(evidence, /<details>[\s\S]*<summary>Evidence<\/summary>[\s\S]*<\/details>/);
+  assert.match(metadata, /<details>[\s\S]*<summary>Metadata<\/summary>[\s\S]*<\/details>/);
+});
+
+test("pr-review distinguishes legacy approved-contract and limited-review traceability", () => {
+  const contract = markdownSection(
+    readRelative("skills/pr-review/SKILL.md"),
+    "Publish and update the summary"
+  );
+  const traceabilityStart = contract.indexOf("| Issue | Spec | Contract |");
+  const resolutionsHeading = contract.match(/^\s*## .*resolv.*$/im);
+  const resolutionsStart = resolutionsHeading ? contract.indexOf(resolutionsHeading[0]) : -1;
+  const evidenceStart = contract.indexOf("<summary>Evidence</summary>");
+  const traceabilityEnd = resolutionsStart === -1 ? evidenceStart : resolutionsStart;
+  const traceability = contract.slice(traceabilityStart, traceabilityEnd);
+
+  assert.notEqual(traceabilityStart, -1, "the compact traceability table exists");
+  assert.match(
+    traceability,
+    /\| none \| `specs\/<path>` \(approved\) \| Contractual review \|/,
+    "an approved legacy contract without issue: has a distinct traceability row"
+  );
+  assert.match(
+    traceability,
+    /\| none \| none \| Limited review \|/,
+    "a limited review remains distinguishable from a legacy contractual review"
+  );
+});
+
+test("pr-review omits empty severity headings from visible findings", () => {
+  const contract = markdownSection(
+    readRelative("skills/pr-review/SKILL.md"),
+    "Publish and update the summary"
+  );
+  const findingsStart = contract.indexOf("## Findings");
+  const traceabilityStart = contract.indexOf("| Issue | Spec | Contract |");
+  const findings = contract.slice(findingsStart, traceabilityStart);
+  const normalizedFindings = findings.replace(/\s+/g, " ");
+
+  assert.match(
+    normalizedFindings,
+    /group visible findings only beneath the severity headings that are present/i,
+    "findings are grouped only under severities that are present"
+  );
+  assert.match(
+    normalizedFindings,
+    /omit every empty severity heading/i,
+    "empty severity headings are omitted"
+  );
+  assert.doesNotMatch(
+    findings,
+    /###\s+Unanchorable/i,
+    "unanchorable findings do not get a separate visible severity"
+  );
+});
+
+test("pr-review keeps prior resolutions human-readable and thread IDs metadata-only", () => {
+  const contract = markdownSection(
+    readRelative("skills/pr-review/SKILL.md"),
+    "Publish and update the summary"
+  );
+  const resolutionsStart = contract.search(/^\s*## .*resol.*$/im);
+  const evidenceStart = contract.indexOf("<summary>Evidence</summary>");
+  const metadata = detailsBlock(contract, "Metadata");
+  const resolutions = contract.slice(resolutionsStart, evidenceStart);
+  const normalizedResolutions = resolutions.replace(/\s+/g, " ");
+
+  assert.notEqual(resolutionsStart, -1, "the optional resolutions guidance exists");
+  assert.match(
+    normalizedResolutions,
+    /Describe each resolution human-first \(the behavior that is now fixed and the evidence\), not as an internal identifier/i,
+    "prior resolutions lead with behavior and evidence"
+  );
+  assert.match(
+    normalizedResolutions,
+    /Keep thread IDs in Metadata only/i,
+    "thread IDs are excluded from visible resolution descriptions"
+  );
+  assert.ok(
+    normalizedResolutions.indexOf("human-first") < normalizedResolutions.indexOf("thread IDs"),
+    "human-readable resolution guidance precedes ID handling"
+  );
+  assert.match(metadata, /IDs are metadata-only/i, "IDs remain metadata-only");
 });
 
 test("GitHub Issues workflows are portable, confirmation-gated, and available through Claude", () => {


### PR DESCRIPTION
Defines the canonical PR-review summary as verdict-first, with visible findings and compact traceability while keeping bookkeeping in details.

Adds approved spec 008 for Issue #55, preserves legacy no-Issue contracts, and keeps limited reviews distinct.

Verified with `node --test tests/*.test.mjs`, packaging validation, Claude validation, and a clean Codex plugin install.

Refs #55