### PR TITLE
feat(workflow-risk): define portable risk contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ sandbox. There is no `plus-ultra:integrate` command.
     `--spec <NNN|slug>` as a fallback. This workflow requires GitHub write access through `gh`.
   - *integration-boundary* — portable policy for ending autonomous work at ready for integration;
     manual merge and publication remain human-owned.
+  - *workflow-risk* — portable FAST / STANDARD / CRITICAL classification contract. It records
+    explainable initial and pre-ship recommendations without commands, hooks, or state: Issue #22
+    owns future orchestration and persistence, Issue #26 owns conditional Semgrep execution, and
+    Issue #35 exclusively owns UI classification. Significant UI impact prevents FAST but never
+    creates a critical risk dimension.
   - *issue-management*, *refine-issues*, *roadmap-planning* — GitHub Issues workflows for native
     milestone → epic → story planning, raw issue refinement, and progress reporting. Remote writes
     are always proposal-first and confirmation-gated.

--- a/skills/workflow-risk/SKILL.md
+++ b/skills/workflow-risk/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: workflow-risk
+description: Use when classifying implementation workflow risk at the start of work or before shipping a change.
+---
+
+# Workflow risk
+
+Use this portable contract to classify the rigor appropriate for a change. It defines a
+recommendation only: it has no commands, hooks, or state, and does not run orchestration.
+Issue #22 owns orchestration and persistence; Issue #26 owns Semgrep execution; Issue #35 owns UI
+classification.
+
+## Conceptual types
+
+```text
+WorkflowLevel = FAST | STANDARD | CRITICAL
+Phase = initial | pre-ship
+RiskDimension =
+  authentication | authorization | security-boundary | payments |
+  database-migration | destructive-data | concurrency |
+  persistence-integrity | critical-infrastructure
+```
+
+## Standard output
+
+Always report a plain, reviewable classification containing:
+
+```text
+phase: initial | pre-ship
+prior level: FAST | STANDARD | CRITICAL | missing
+suggested level: FAST | STANDARD | CRITICAL
+effective level: FAST | STANDARD | CRITICAL
+detected/new dimensions: <deduplicated RiskDimension list>
+evidence: <observations, assumptions, and uncertainty>
+required verification: <baseline rigor plus dimension controls>
+explicit override: <none, or who/what explicitly changes level or dimensions>
+```
+
+At `initial`, effective level normally equals the suggested level. At `pre-ship`, preserve the
+classification history: effective level is the maximum of prior and current classification, and
+dimensions accumulate. Missing prior classification must not silently infer a downgrade; say so.
+Only an explicit override may lower a level or remove dimensions. Keep that override
+visible, and never use it to disable baseline guardrails.
+
+## Classification precedence
+
+Apply these rules in order:
+
+1. A known critical trigger in any RiskDimension produces `CRITICAL`.
+2. Suggest `FAST` only after proving every restriction: the change is small and localized, has no
+   significant UI impact, introduces no critical dimension, is understood rather than ambiguous,
+   and has focused verification.
+3. Every other change, including uncertainty without critical evidence, is `STANDARD`.
+4. At `pre-ship`, effective level is the maximum of prior and current classification, even if the
+   current diff is smaller; dimensions accumulate.
+5. Only an explicit override may lower a level or remove dimensions; keep the override visible and
+   do not disable baseline guardrails.
+6. Missing prior classification at `pre-ship` must not silently infer a downgrade.
+
+Significant UI impact prevents `FAST` but never creates a critical dimension. Leave UI
+classification exclusively to Issue #35; do not invent a UI RiskDimension.
+
+## Baseline rigor
+
+### FAST
+
+Require a small, localized change and focused verification. Commit guardrails remain in force;
+optional review is permitted and no required durable artifact is created.
+
+### STANDARD
+
+Use the normal Issue, design, or spec process as applicable; write a plan; use TDD; run the
+relevant suite; obtain review; and prepare a PR.
+
+### CRITICAL
+
+Require all STANDARD requirements, an approved spec, and mandatory review. Also require the
+de-duplicated union of controls for every detected/new dimension.
+
+## Per-dimension controls
+
+### authentication
+
+Test permitted and denied cases across sessions, roles, and tenancy; use integration coverage and
+security review.
+
+### authorization
+
+Test permitted and denied cases across sessions, roles, and tenancy; use integration coverage and
+security review.
+
+### security-boundary
+
+Exercise abuse cases and trust-boundary validation. Run Semgrep when available; its execution and
+availability handling belong to Issue #26.
+
+### payments
+
+Test idempotency, retries, duplicates, amounts, currencies, rounding, and reconciliation.
+
+### database-migration
+
+Use representative fixtures; verify compatibility, roll-forward, rollback, and data safety.
+
+### destructive-data
+
+Verify authorization and confirmation, scope, recovery, and partial failures.
+
+### concurrency
+
+Test races, ordering, retries, and concurrent integration behavior.
+
+### persistence-integrity
+
+Test atomicity, invariants, restarts, idempotency, and partial failures.
+
+### critical-infrastructure
+
+Verify configuration and permissions, integration, degradation, recovery, and rollback.
+
+## Worked classification scenarios
+
+- **FAST-localized change:** A small, localized, one-file copy correction with focused verification,
+  no UI impact, no critical trigger, and all FAST restrictions proven is FAST.
+- **Ambiguous STANDARD:** An incompletely understood change without critical evidence is STANDARD.
+- **One CRITICAL dimension:** A tenancy authorization change is CRITICAL and includes the
+  authorization controls.
+- **Multiple CRITICAL dimensions:** A payment migration is CRITICAL and requires the de-duplicated
+  union of payments and database-migration controls.
+- **FAST→STANDARD:** A previously localized change that expands beyond a FAST restriction becomes
+  STANDARD at pre-ship.
+- **STANDARD→CRITICAL:** A standard change that exposes a known security-boundary trigger becomes
+  CRITICAL at pre-ship.
+- **Smaller diff retaining prior level:** A smaller pre-ship diff after a CRITICAL prior level
+  remains CRITICAL and retains prior dimensions.
+- **Explicit override:** Record an explicit override that lowers a level or removes dimensions;
+  keep it visible and retain baseline guardrails.
+- **Missing prior classification:** At pre-ship with no known critical evidence or trigger, report
+  missing prior classification; classification remains STANDARD and does not infer a silent
+  downgrade. Any known critical trigger remains CRITICAL despite missing prior history.

--- a/specs/009-classify-workflow-risk.md
+++ b/specs/009-classify-workflow-risk.md
@@ -1,0 +1,107 @@
+---
+title: Classify workflow risk
+status: approved
+issue: 23
+created: 2026-09-07
+---
+
+# 009 — Classify workflow risk
+
+## Problem
+
+The plugin has no portable, shared way to choose FAST, STANDARD, or CRITICAL workflow rigor. That
+leaves agents to make inconsistent choices, especially when a change grows between initial planning
+and pre-ship review.
+
+## Goals / Non-goals
+
+**Goals**
+
+- Define the portable `workflow-risk` skill's exact levels, phases, dimensions, output, precedence,
+  baseline rigor, and per-dimension controls.
+- Preserve monotonic pre-ship classification unless a visible explicit override says otherwise.
+- Make the skill discoverable while keeping Issue #22, #26, and #35 ownership boundaries clear.
+
+**Non-goals**
+
+- Add orchestration, persistence, commands, hooks, manifests, Semgrep execution, or agent-specific
+  mechanics.
+- Classify UI impact beyond its effect on FAST eligibility.
+
+## Acceptance criteria
+
+- [x] `skills/workflow-risk/SKILL.md` is portable, has `workflow-risk` frontmatter, and begins its
+      description with `Use when`.
+- [x] The contract defines exactly FAST, STANDARD, CRITICAL; initial and pre-ship; and the nine
+      named risk dimensions.
+- [x] Its output includes phase, prior/suggested/effective levels, detected/new dimensions,
+      evidence, required verification, and explicit override.
+- [x] It gives CRITICAL, FAST, STANDARD, monotonic pre-ship, accumulated-dimension, override, and
+      missing-prior precedence rules.
+- [x] It defines FAST, STANDARD, and CRITICAL rigor plus the de-duplicated per-dimension union.
+- [x] It covers every specified per-dimension verification control and treats Semgrep as conditional
+      execution owned by Issue #26.
+- [x] Significant UI impact blocks FAST but creates no critical dimension; Issue #35 retains UI
+      classification ownership and Issue #22 retains orchestration/persistence ownership.
+- [x] README discovery and contract tests cover all required classification scenarios without
+      introducing commands, hooks, or state.
+
+## Interface contracts
+
+The portable conceptual interface is:
+
+```text
+WorkflowLevel = FAST | STANDARD | CRITICAL
+Phase = initial | pre-ship
+RiskDimension = authentication | authorization | security-boundary | payments |
+                database-migration | destructive-data | concurrency |
+                persistence-integrity | critical-infrastructure
+```
+
+Each classification reports phase, prior level, suggested level, effective level, detected/new
+dimensions, evidence, required verification, and explicit override. A known critical trigger is
+CRITICAL. FAST requires proving every restriction. All other changes—including uncertainty without
+critical evidence—are STANDARD. At pre-ship use the maximum of prior and current classification and
+accumulate dimensions. An explicit visible override is the sole way to lower a level or remove a
+dimension, and cannot disable baseline guardrails.
+
+## Architecture boundaries
+
+`skills/workflow-risk/SKILL.md` is the portable policy source. `README.md` is discovery-only and
+`tests/skills.test.mjs` checks the documented contract. Issue #22 may orchestrate or persist this
+result later; Issue #26 may execute Semgrep later; Issue #35 exclusively classifies UI. No adapter,
+command, hook, manifest, persistence store, or agent-specific implementation is part of this work.
+
+## Functional core
+
+Classification is a pure, explainable decision: identify dimensions and evidence, select the current
+level using precedence, then combine it with prior classification at pre-ship. Verification is a
+deduplicated union of baseline rigor and dimension controls. Any override is an explicit input that
+remains in the output rather than an implicit mutation of the result.
+
+## Data model
+
+No persisted schema is introduced. The conceptual result fields are:
+
+```text
+phase, priorLevel, suggestedLevel, effectiveLevel, detectedNewDimensions,
+evidence, requiredVerification, explicitOverride
+```
+
+## Test plan
+
+- Add contract tests before the skill exists and observe the expected missing-file failure.
+- Verify discovery, frontmatter, exact vocabulary, precedence, FAST guardrails, initial/pre-ship
+  output, monotonic escalation, dimension accumulation, explicit overrides, unioned controls, UI
+  separation, Semgrep delegation, spec linkage, and README boundaries.
+- Cover FAST-localized, ambiguous STANDARD, one/multiple CRITICAL, FAST→STANDARD,
+  STANDARD→CRITICAL, retained-prior, explicit-override, and missing-prior scenarios.
+- Run focused skills tests, the full test suite, package validation, Claude validation, and
+  whitespace validation before committing.
+
+## Risks
+
+A reader could treat a heuristic as hidden automation, downgrade a pre-ship change from a smaller
+diff, or duplicate work owned by adjacent issues. The visible output, explicit override rule,
+monotonic pre-ship rule, and ownership boundaries mitigate those risks. This documentation-only
+contract can be revised through a later approved spec if practical execution reveals a gap.

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -58,6 +58,173 @@ function parseFrontmatter(markdown) {
   );
 }
 
+test("workflow-risk is a portable, issue-linked FAST/STANDARD/CRITICAL contract", () => {
+  const skillPath = "skills/workflow-risk/SKILL.md";
+  assert.ok(existsSync(join(repoRoot, skillPath)), `${skillPath} exists`);
+
+  const skill = readRelative(skillPath);
+  const spec = readRelative("specs/009-classify-workflow-risk.md");
+  const readme = readRelative("README.md");
+  const frontmatter = parseFrontmatter(skill);
+  const normalized = skill.replace(/\s+/g, " ");
+  const precedence = markdownSection(skill, "Classification precedence").replace(/\s+/g, " ");
+  const standardOutput = markdownSection(skill, "Standard output").replace(/\s+/g, " ");
+  const baselineRigor = markdownSection(skill, "Baseline rigor").replace(/\s+/g, " ");
+  const scenarios = markdownSection(skill, "Worked classification scenarios").replace(/\s+/g, " ");
+
+  assert.equal(frontmatter.name, "workflow-risk");
+  assert.match(frontmatter.description, /^Use when/);
+  assert.match(readme, /workflow-risk/);
+  assert.match(spec, /^title: Classify workflow risk$/m);
+  assert.match(spec, /^status: approved$/m);
+  assert.match(spec, /^issue: 23$/m);
+  assert.match(spec, /^created: 2026-09-07$/m);
+
+  assert.match(skill, /WorkflowLevel\s*=\s*FAST\s*\|\s*STANDARD\s*\|\s*CRITICAL/);
+  assert.match(skill, /Phase\s*=\s*initial\s*\|\s*pre-ship/);
+  const dimensions = [
+    "authentication",
+    "authorization",
+    "security-boundary",
+    "payments",
+    "database-migration",
+    "destructive-data",
+    "concurrency",
+    "persistence-integrity",
+    "critical-infrastructure",
+  ];
+  const dimensionDefinition = skill.match(/RiskDimension\s*=\s*([\s\S]*?)\n```/);
+  assert.ok(dimensionDefinition, "RiskDimension is defined in a code block");
+  assert.deepEqual(
+    dimensionDefinition[1].match(/[a-z]+(?:-[a-z]+)*/g),
+    dimensions,
+    "RiskDimension has the exact nine-dimension vocabulary"
+  );
+
+  for (const field of [
+    "phase",
+    "prior level",
+    "suggested level",
+    "effective level",
+    "detected/new dimensions",
+    "evidence",
+    "required verification",
+    "explicit override",
+  ]) {
+    assert.match(normalized, new RegExp(field, "i"), `output contains ${field}`);
+  }
+  for (const [rule, outcome] of [
+    ["1", "known critical trigger.*?CRITICAL"],
+    ["2", "FAST.*?every restriction"],
+    ["3", "uncertainty.*?without critical evidence.*?STANDARD"],
+    ["4", "pre-ship.*?max.*?prior.*?current.*?dimensions.*?accumulate"],
+    ["5", "only.*?explicit override.*?(?:lower|remove).*?visible.*?baseline guardrails"],
+    ["6", "missing prior.*?must not.*?downgrade"],
+  ]) {
+    assert.match(precedence, new RegExp(`${rule}\\. .*?${outcome}`, "i"), `precedence rule ${rule}`);
+  }
+  assert.ok(
+    precedence.indexOf("1.") < precedence.indexOf("2.") &&
+      precedence.indexOf("2.") < precedence.indexOf("3.") &&
+      precedence.indexOf("3.") < precedence.indexOf("4.") &&
+      precedence.indexOf("4.") < precedence.indexOf("5.") &&
+      precedence.indexOf("5.") < precedence.indexOf("6."),
+    "precedence rules retain their ordered outcomes"
+  );
+  assert.match(standardOutput, /pre-ship.*?maximum of prior and current classification.*?dimensions accumulate/i);
+  assert.match(standardOutput, /only an explicit override.*?(?:lower|remove).*?override visible.*?baseline guardrails/i);
+  assert.match(baselineRigor, /CRITICAL.*?de-duplicated union.*?every detected\/new dimension/i);
+
+  assert.match(normalized, /FAST.*?small.*?localized.*?focused verification.*?commit guardrails.*?optional review.*?no required durable artifact/i);
+  assert.match(normalized, /STANDARD.*?Issue.*?design.*?spec.*?plan.*?TDD.*?relevant suite.*?review.*?PR/i);
+  assert.match(normalized, /CRITICAL.*?all STANDARD.*?approved spec.*?mandatory review.*?de-duplicated union/i);
+
+  for (const [dimension, checks] of [
+    ["authentication", ["permitted", "denied", "sessions", "roles", "tenancy", "integration", "security review"]],
+    ["authorization", ["permitted", "denied", "sessions", "roles", "tenancy", "integration", "security review"]],
+    ["security-boundary", ["abuse", "trust-boundary", "Semgrep when available"]],
+    ["payments", ["idempotency", "retries", "duplicates", "amounts", "currencies", "rounding", "reconciliation"]],
+    ["database-migration", ["representative fixtures", "compatibility", "roll-forward", "rollback", "data safety"]],
+    ["destructive-data", ["authorization", "confirmation", "scope", "recovery", "partial failures"]],
+    ["concurrency", ["races", "ordering", "retries", "concurrent integration"]],
+    ["persistence-integrity", ["atomicity", "invariants", "restarts", "idempotency", "partial failures"]],
+    ["critical-infrastructure", ["configuration", "permissions", "integration", "degradation", "recovery", "rollback"]],
+  ]) {
+    const section = markdownSubsection(skill, dimension).replace(/\s+/g, " ");
+    for (const check of checks) assert.match(section, new RegExp(check, "i"), `${dimension}: ${check}`);
+  }
+
+  const typeOnlyText = "WorkflowLevel = FAST | STANDARD | CRITICAL";
+  assert.doesNotMatch(typeOnlyText, /\*\*FAST→STANDARD:\*\*/, "type-only text is not a transition scenario");
+  function workedScenario(label) {
+    const marker = `**${label}:**`;
+    const start = scenarios.indexOf(marker);
+    assert.notEqual(start, -1, `${label} exists in worked scenarios`);
+    const end = scenarios.indexOf(" - **", start + marker.length);
+    return scenarios.slice(start + marker.length, end === -1 ? undefined : end);
+  }
+  function assertRetainedPriorScenario(text) {
+    assert.match(text, /smaller pre-ship diff/i);
+    assert.match(text, /CRITICAL prior level/i);
+    assert.match(text, /remains CRITICAL/i);
+    assert.match(text, /prior dimensions/i);
+  }
+
+  assert.match(
+    workedScenario("FAST-localized change"),
+    /small.*?localized.*?no critical (?:trigger|new risk).*?(?:is|results) FAST/i,
+    "localized FAST scenario proves eligibility and outcome"
+  );
+  assert.match(
+    workedScenario("Ambiguous STANDARD"),
+    /incompletely understood.*?(?:is|results) STANDARD/i,
+    "ambiguous scenario selects STANDARD"
+  );
+  assert.match(
+    workedScenario("One CRITICAL dimension"),
+    /tenancy authorization.*?CRITICAL.*?authorization controls/i,
+    "one critical dimension selects CRITICAL with its controls"
+  );
+  assert.match(
+    workedScenario("Multiple CRITICAL dimensions"),
+    /payment migration.*?CRITICAL.*?de-duplicated union.*?payments.*?database-migration controls/i,
+    "multiple critical dimensions retain both dimensions and union controls"
+  );
+  assert.match(
+    workedScenario("FAST→STANDARD"),
+    /previously localized.*?expands.*?becomes STANDARD at pre-ship/i,
+    "FAST→STANDARD names its source condition and outcome in the worked scenarios"
+  );
+  assert.match(
+    workedScenario("STANDARD→CRITICAL"),
+    /standard change.*?security-boundary trigger.*?becomes CRITICAL at pre-ship/i,
+    "STANDARD→CRITICAL names its source condition and outcome in the worked scenarios"
+  );
+  assertRetainedPriorScenario(workedScenario("Smaller diff retaining prior level"));
+  assert.throws(
+    () => assertRetainedPriorScenario("A smaller pre-ship diff after a CRITICAL prior level remains FAST."),
+    /remains CRITICAL|prior dimensions/,
+    "retained-prior validator rejects a FAST downgrade without prior dimensions"
+  );
+  assert.match(
+    workedScenario("Explicit override"),
+    /lowers a level or removes dimensions.*?visible.*?baseline guardrails/i,
+    "explicit override remains visible and preserves baseline guardrails"
+  );
+  assert.match(
+    workedScenario("Missing prior classification"),
+    /pre-ship.*?no known critical (?:evidence|trigger).*?remains STANDARD.*?(?:no|does not infer a) silent downgrade.*?known critical trigger.*?remains CRITICAL/i,
+    "missing prior classification remains STANDARD only without critical evidence and preserves CRITICAL precedence"
+  );
+  assert.match(normalized, /significant UI impact.*?prevents.*?FAST.*?never.*?critical dimension/i);
+  assert.match(normalized, /#35.*?UI classification/i);
+  assert.match(normalized, /#22.*?(?:orchestration|persistence)/i);
+  assert.match(normalized, /#26.*?Semgrep.*?when available/i);
+  assert.match(normalized, /no commands.*?hooks.*?state/i);
+  assert.match(readme, /#22[\s\S]*?#26[\s\S]*?#35/);
+  assert.doesNotMatch(readme, /workflow-risk[^\n]*(?:command|hook|state)/i);
+});
+
 test("spec lifecycle links optional GitHub Issues without owning work state", () => {
   const template = readRelative("skills/spec-conventions/template.md");
   const conventions = readRelative("skills/spec-conventions/SKILL.md");


### PR DESCRIPTION
## At a glance

Adds a portable workflow-risk policy that gives maintainers a consistent FAST, STANDARD, or CRITICAL classification before implementation and again before shipping. It preserves escalation evidence across phases without adding runtime automation or persisted state.

## Context

Issue #23 needs a reusable contract for selecting workflow rigor from detected risk dimensions. The policy stays documentation-first: orchestration is deferred to #22, Semgrep execution to #26, and UI classification to #35.

## Traceability

- Issue: #23
- Spec: `specs/009-classify-workflow-risk.md` (approved)
- Refs #23

## Summary

- Adds `plus-ultra:workflow-risk`, including exact risk dimensions, level precedence, pre-ship monotonic escalation, explicit overrides, and per-dimension verification controls.
- Adds approved spec 009, README discovery, and contract tests for the portable policy and its worked scenarios.
- Keeps manifests, commands, hooks, scripts, persistence, and agent-specific logic unchanged.

## Testing

- `node --test tests/skills.test.mjs` — 24 passed
- `node --test tests/*.test.mjs` — 127 passed
- `node scripts/validate-packaging.mjs .` — passed
- `claude plugin validate .` — passed
- `git diff --check origin/main...HEAD` — passed
- Clean `CODEX_HOME` marketplace add and `plus-ultra@plus-ultra` install — passed

## Risks

None known. The policy deliberately delegates execution and persistence to the linked follow-up issues.

## Review Guidance

- Check the precedence and pre-ship examples in `skills/workflow-risk/SKILL.md`, especially that known critical triggers override absent prior history.
- Confirm the scenario tests are scoped to their examples and preserve the no-silent-downgrade rule.
