### PR TITLE
feat(product): add durable product discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,31 @@ design, use plus-ultra:spec to create and manage the repository spec, write the 
 plan, implement it with TDD, verify the result, and prepare the pull request.
 ```
 
+## Durable product discovery
+
+For a greenfield project, `plus-ultra:new-project` invokes `$product-discovery` before stack
+selection or scaffolding when `docs/product.md` is missing. Discovery proposes the product brief
+for explicit human approval; only then can stack selection and scaffolding continue.
+
+Only `plus-ultra:product-discovery` may create `docs/product.md` as the initial brief and make
+approved strategic updates to it. Every other workflow treats a present brief as read-only context
+and must not create, edit, or append to it. Existing repositories without a brief remain compatible
+and continue normally; they do not implicitly gain one.
+
+Read-only context keeps related work aligned without turning the brief into a plan or backlog:
+
+- `plus-ultra:roadmap-planning` bounds milestones and stories with the MVP hypothesis, core user
+  journeys, non-goals, and success criteria.
+- `plus-ultra:refine-issues` checks that a story fits the approved product direction.
+- `plus-ultra:spec` reads it while creating a new technical contract; list, link, and status work
+  independently when no brief is present.
+- `plus-ultra:spec-conventions` reads it before brainstorming, feature work, and significant
+  design.
+
+When proposed work creates a durable contradiction with the brief, pause that workflow for a
+focused rediscovery update through `$product-discovery`. Resume only after the resulting update
+has explicit human approval.
+
 ## Optional companions
 
 `plus-ultra` stays focused on spec-driven development. For day-to-day projects, it pairs well with

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -8,6 +8,19 @@ description: Scaffold a new project with the plus-ultra default stack — a pnpm
 Bootstraps the `plus-ultra:tech-stack` defaults. Confirm the stack with the user first if they
 haven't stated one — this skill fills silence, it doesn't override stated preferences.
 
+## Product discovery gate
+
+Before stack selection or scaffolding, identify whether this is greenfield work. For a greenfield
+project missing `docs/product.md`, invoke `$product-discovery` for initial adaptive discovery;
+explicit human approval of its proposed brief is required before stack selection or scaffolding.
+When `docs/product.md` exists, read the approved brief as product context; it informs stack and
+scaffolding decisions without changing the brief.
+
+An existing repository without a brief remains compatible: continue normally and never create,
+edit, write, or mutate `docs/product.md` implicitly. If proposed scaffolding creates a durable
+contradiction with a present brief, pause the current workflow, invoke `$product-discovery` for a
+focused rediscovery update; only after its explicit human approval, resume the current workflow.
+
 ## Before scaffolding
 
 - Confirm project name and whether they want the full **monorepo** (default) or a **single package**

--- a/skills/product-discovery/SKILL.md
+++ b/skills/product-discovery/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: product-discovery
+description: Use when establishing or strategically updating a durable product brief, or when product direction needs focused discovery before work continues.
+---
+
+# plus-ultra product discovery
+
+Own the current, human-approved product state at `docs/product.md`. Only
+`plus-ultra:product-discovery` may create, write, or strategically update that file. It is not an
+interview transcript, decision journal, roadmap, or implementation plan.
+
+## Modes and ownership
+
+Use one of these modes deliberately:
+
+1. **Initial adaptive discovery** establishes a missing brief.
+2. **Focused strategic update** changes an existing brief after a requested strategic change or a
+   durable contradiction.
+3. **Read-only consumption mode** reads an existing brief as context without changing it.
+
+Other workflows are read-only consumers: they may apply a present brief as context, but must not
+create, edit, append to, or implicitly create `docs/product.md`. A repository without a brief is
+read-only-compatible: do not create one implicitly, and let ordinary existing-repository work
+continue normally.
+
+## Initial adaptive discovery
+
+Ground discovery in relevant conversation and repository context. State material assumptions
+visibly rather than presenting them as facts. Ask one relevant decision at a time; adapt the next
+decision to what is already known.
+
+For every consequential decision, offer two or three alternatives, explain the trade-offs, and
+give a recommendation. Challenge any requested scope that lacks a clear connection to the MVP
+hypothesis; do not silently encode it as a product decision.
+
+When the required decisions are clear, fill in the complete canonical template from
+[`assets/product.md`](./assets/product.md). Show the full visible proposal before creating the
+file. Write `docs/product.md` only after explicit human approval. If the proposal is declined or
+unapproved, leave the file unchanged.
+
+## Focused strategic update
+
+Use this mode for a material revision to the target user, problem, alternative, value proposition,
+MVP hypothesis, journeys, non-goals, success criteria, or product principles and constraints.
+
+Identify the affected decisions. A focused update shows only affected decisions for explicit human
+approval, while preserving unaffected sections—all canonical sections not affected—verbatim in
+meaning.
+Do not write until approval; a declined or unapproved update leaves `docs/product.md` unchanged.
+
+After approval, rewrite the complete brief as its current state. Replace the prior document rather
+than appending a journal, history, transcript, or decision log. Retain exactly the canonical
+section sequence from [`assets/product.md`](./assets/product.md).
+
+## Read-only consumption
+
+When a brief exists, read it as product context and leave it unchanged. If proposed work creates a
+durable contradiction—both the brief and the work cannot materially remain true—pause the current
+workflow and route to focused strategic update. Resume only after the resulting update has explicit
+human approval. Leave implementation-level choices with the current workflow.
+
+## Canonical brief
+
+The sole durable brief path is `docs/product.md`. Start it from
+[`assets/product.md`](./assets/product.md), retain its title and exact level-2 heading order, and
+write only the current approved product state.

--- a/skills/product-discovery/agents/openai.yaml
+++ b/skills/product-discovery/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Product Discovery"
+  short_description: "Establish or update an approved current-state product brief"
+  default_prompt: "Use $product-discovery to establish or strategically update this product brief."

--- a/skills/product-discovery/assets/product.md
+++ b/skills/product-discovery/assets/product.md
@@ -1,0 +1,19 @@
+# Product brief
+
+## Target user
+
+## Core problem
+
+## Current alternative
+
+## Value proposition
+
+## MVP hypothesis
+
+## Core user journeys
+
+## Non-goals
+
+## Success criteria
+
+## Product principles and constraints

--- a/skills/refine-issues/SKILL.md
+++ b/skills/refine-issues/SKILL.md
@@ -8,6 +8,17 @@ description: Use when a person-created GitHub issue needs a structured, reviewab
 Accept one positive **issue number**. Read the issue, its labels, milestone, parent, and relevant
 repository context. Follow `plus-ultra:issue-management` for repository access and mutation safety.
 
+## Durable product context
+
+When `docs/product.md` exists, read it as product context and check whether the proposed story fits
+the approved direction. A repository without a brief remains compatible: continue refinement
+normally and never create, edit, write, or mutate `docs/product.md` implicitly.
+
+If the proposed story creates a durable contradiction with a present brief, pause the current
+workflow, invoke `$product-discovery` for a focused rediscovery update; only after its explicit
+human approval, resume the current workflow. This workflow consumes the brief read-only and does not make the
+strategic decision itself.
+
 ## Proposal
 
 Classify the issue as a story or epic from its scope, then show a proposed title, labels, milestone,

--- a/skills/roadmap-planning/SKILL.md
+++ b/skills/roadmap-planning/SKILL.md
@@ -8,6 +8,18 @@ description: Use when a roadmap brief or GitHub issue needs to be broken into mi
 Accept a roadmap brief or an existing issue. If an issue is supplied, read it before planning. Follow
 `plus-ultra:issue-management` for taxonomy, repository access, and mutation safety.
 
+## Durable product context
+
+When `docs/product.md` exists, read it as product context before decomposition. Use its MVP
+hypothesis, core user journeys, non-goals, and success criteria to bound milestones, epics, and
+stories. A repository without a brief remains compatible: continue planning normally and never
+create, edit, write, or mutate `docs/product.md` implicitly.
+
+If proposed roadmap work creates a durable contradiction with a present brief, pause the current
+workflow, invoke `$product-discovery` for a focused rediscovery update; only after its explicit
+human approval, resume the current workflow. This workflow only consumes the approved brief; it does not resolve a
+strategic conflict itself.
+
 ## Decompose before writing
 
 Propose one Milestone, then a tree of Epics and independent Stories. Every Story must state its

--- a/skills/spec-conventions/SKILL.md
+++ b/skills/spec-conventions/SKILL.md
@@ -8,6 +8,18 @@ description: Use when creating, organizing, tracking, or resuming specs; when Su
 Superpowers owns the *methodology* (brainstorming → writing-plans → subagent TDD → verification).
 This skill owns the *repo conventions* for where that work lives and how its state is tracked.
 
+## Durable product context
+
+When `docs/product.md` exists, read it as product context before brainstorming, feature work, or
+significant design. Use the approved direction to frame the work while leaving the brief unchanged.
+A repository without a brief remains compatible: continue normally and never create, edit, write,
+or mutate `docs/product.md` implicitly.
+
+If proposed brainstorming, feature work, or significant design creates a durable contradiction
+with a present brief, pause the current workflow, invoke `$product-discovery` for a focused
+rediscovery update; only after its explicit human approval, resume the current workflow. This workflow is a read-only
+consumer and does not settle strategic product changes itself.
+
 ## Working artifacts stay local
 
 Override Superpowers' default artifact paths so intermediate process documents do not become

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -10,6 +10,18 @@ Use this skill as the portable equivalent of Claude Code's `/plus-ultra:spec` co
 Follow `plus-ultra:spec-conventions` for numbering and lifecycle rules. GitHub Issues own work
 progress; a spec records only its technical-contract lifecycle.
 
+## Durable product context
+
+When creating a new technical contract, read a present `docs/product.md` as product context before
+shaping the contract. A repository without a brief remains compatible: continue normally and never
+create, edit, write, or mutate `docs/product.md` implicitly. The administrative `list`, `link`, and
+`status` operations continue without a missing brief and do not block on product discovery.
+
+If a new contract creates a durable contradiction with a present brief, pause the current workflow,
+invoke `$product-discovery` for a focused rediscovery update; only after its explicit human
+approval, resume the current workflow. This workflow consumes the brief read-only; it never resolves or writes the strategic
+change.
+
 ## Supported requests
 
 Use this complete grammar:

--- a/specs/010-add-durable-product-brief.md
+++ b/specs/010-add-durable-product-brief.md
@@ -1,0 +1,180 @@
+---
+title: Add durable product brief
+status: approved
+issue: 36
+created: 2026-09-07
+---
+
+# 010 — Add durable product brief
+
+## Problem
+
+Product intent is currently held in transient conversations and individual workflow artifacts.
+Consequently, new-project scaffolding, planning, issue refinement, specification work, and
+significant design or feature work can proceed from inconsistent assumptions. The plugin needs one
+portable, human-approved current-state product brief without making product discovery an implicit
+side effect of unrelated workflows.
+
+## Goals / Non-goals
+
+**Goals**
+
+- Add a portable `plus-ultra:product-discovery` skill as the exclusive owner of creating and
+  strategically updating `docs/product.md`.
+- Define one canonical, current-state product-brief structure and an approval-gated discovery
+  interaction for initial discovery and focused updates.
+- Let existing workflows consume a present brief, while preserving their current behavior for
+  repositories that do not have one.
+- Require a focused rediscovery pause before a workflow continues through a durable contradiction
+  with the approved brief.
+
+**Non-goals**
+
+- Add commands, hooks, scripts, dependencies, manifests, persistent workflow state, or
+  platform-specific behavior.
+- Make a consumer workflow create or mutate `docs/product.md`, including as a fallback when it is
+  missing.
+- Turn `docs/product.md` into an interview transcript, decision log, roadmap, implementation
+  plan, or append-only journal.
+- Change the ownership of implementation planning, technical specifications, issue progress, or
+  stack selection after the required greenfield gate.
+
+## Acceptance criteria
+
+- [ ] `skills/product-discovery/SKILL.md` is a portable, namespaced
+      `plus-ultra:product-discovery` skill and is the only workflow authorized to create or make
+      strategic updates to `docs/product.md`.
+- [ ] `docs/product.md` contains exactly the following canonical sections, in this exact order:
+      `Target user`; `Core problem`; `Current alternative`; `Value proposition`; `MVP hypothesis`;
+      `Core user journeys`; `Non-goals`; `Success criteria`; `Product principles and constraints`.
+- [ ] Product discovery supports initial adaptive discovery, focused update, and read-only
+      consumption modes with the behaviors defined by this contract.
+- [ ] An initial write and every strategic change show a complete visible proposal and require
+      explicit human approval before `docs/product.md` is written; declined or unapproved proposals
+      leave the file unchanged.
+- [ ] A focused update shows only affected decisions, preserves every unaffected canonical section,
+      and rewrites the brief as current state rather than appending historical entries.
+- [ ] The discovery interview uses conversation-supported context, makes material assumptions
+      visible, asks one relevant decision at a time, presents two or three alternatives with
+      trade-offs and a recommendation, and challenges requested scope that is not tied to the MVP
+      hypothesis.
+- [ ] `plus-ultra:new-project` stops greenfield scaffolding before stack selection when no brief
+      exists, and routes the user to initial discovery rather than selecting a stack.
+- [ ] When `docs/product.md` exists, `roadmap-planning`, `refine-issues`, `spec`, and significant
+      design or feature work through `spec-conventions` consume it as context without creating or
+      mutating it.
+- [ ] Existing repositories without `docs/product.md` continue those consumer workflows without
+      errors or implicit brief creation.
+- [ ] A durable contradiction found by a consumer pauses its current workflow for focused
+      rediscovery; it resumes only after the resulting change has explicit human approval.
+- [ ] Contract tests cover structure, ownership, modes, approval gating, consumer behavior,
+      missing-brief compatibility, contradiction pauses, and the absence of new platform-specific
+      surfaces.
+
+## Interface contracts
+
+The only durable product-brief path is `docs/product.md`. It is a current-state Markdown document
+with exactly this section sequence and no alternative or supplementary product-decision sections:
+
+```markdown
+# Product brief
+
+## Target user
+## Core problem
+## Current alternative
+## Value proposition
+## MVP hypothesis
+## Core user journeys
+## Non-goals
+## Success criteria
+## Product principles and constraints
+```
+
+`plus-ultra:product-discovery` has three conceptual modes:
+
+1. **Initial adaptive discovery** — used to establish a missing brief. It uses relevant
+   conversation-supported context, labels material assumptions, and asks one decision at a time.
+   Each question offers two or three alternatives, their trade-offs, and a recommendation. Before
+   writing, it displays the entire proposed brief and waits for explicit human approval.
+2. **Focused update** — used for a requested strategic change or a durable contradiction. It
+   identifies the affected decisions, displays only those proposed decisions for approval, retains
+   all unaffected sections verbatim in meaning, then writes a complete replacement current-state
+   brief only after explicit approval.
+3. **Read-only consumption** — used by all other workflows. A consumer may read and apply an
+   existing brief as context, but never creates, edits, or appends to it.
+
+A strategic change includes a material revision to the target user, problem, alternative, value
+proposition, MVP hypothesis, journeys, non-goals, success criteria, or product principles and
+constraints. The skill must challenge scope that lacks a clear connection to the MVP hypothesis;
+it must not silently encode that scope as a product decision.
+
+The consumer gate is:
+
+```text
+new-project + no docs/product.md (greenfield) -> initial adaptive discovery -> approved brief
+                                                 -> stack selection and scaffolding
+consumer + docs/product.md                    -> read-only consumption
+consumer + no docs/product.md (existing repo) -> continue normally
+durable contradiction                         -> pause -> focused update -> explicit approval
+                                                 -> resume current workflow
+```
+
+`new-project` applies its missing-brief gate only to greenfield scaffolding and before stack
+selection. `roadmap-planning`, `refine-issues`, `spec`, and significant design or feature work
+that enters through `spec-conventions` are consumers. A contradiction is durable when the proposed
+work would materially conflict with the brief rather than merely require an implementation-level
+choice; consumers pause rather than resolve it themselves.
+
+## Architecture boundaries
+
+`skills/product-discovery/SKILL.md` is the portable owner of discovery, proposal display, approval,
+and the sole write authority for `docs/product.md`. `docs/product.md` is the durable product-state
+artifact it owns. `skills/new-project/SKILL.md` owns the greenfield pre-stack gate. The
+`roadmap-planning`, `refine-issues`, `spec`, and `spec-conventions` skills remain read-only
+consumers, with `spec-conventions` defining the entry point for significant design and feature
+work.
+
+No host-specific command, hook, script, manifest, dependency, adapter, or runtime behavior is part
+of this design. Conversation and human approval are interaction boundaries; durable file writes are
+isolated exclusively behind the product-discovery skill.
+
+## Functional core
+
+The policy is a deterministic decision over: whether a brief exists, workflow role, repository
+context, whether a proposed change is strategic, and whether a durable contradiction is present.
+It yields one of initial discovery, focused update, read-only consumption, normal continuation, or
+pause pending approved rediscovery. The human interview and filesystem write are side effects; the
+approval decision is explicit input and no unapproved proposal changes durable state.
+
+## Data model
+
+The sole new durable shape is `docs/product.md` with the canonical sections in the Interface
+contracts section. It stores the current approved product state only. It stores no approval marker,
+interview transcript, historical revisions, workflow status, or platform-specific metadata.
+
+## Test plan
+
+- Add contract tests for product-discovery frontmatter, portability, sole-write ownership, the
+  exact ordered canonical headings, and current-state replacement semantics.
+- Test initial discovery proposal visibility and explicit approval; test focused updates expose only
+  affected decisions, preserve unaffected sections, and do not write when unapproved.
+- Test conversation-context use, visible material assumptions, one-decision questioning, two-to-three
+  option trade-offs with a recommendation, and MVP-hypothesis scope challenge behavior.
+- Test the greenfield new-project gate occurs before stack selection, consumers read a present
+  brief, repositories without one continue normally, and durable contradictions pause then resume
+  only after focused-update approval.
+- Run focused contract tests, the full Node suite, `git diff --check`, package validation, and
+  applicable Claude and Codex packaging validation when implementation begins.
+
+## Risks
+
+- An overly broad contradiction rule could interrupt routine implementation work; restrict it to
+  material product-state conflicts and leave technical choices with the consumer workflow.
+- An overly narrow rule could let product intent drift; require focused rediscovery whenever the
+  durable brief and proposed work cannot both remain true.
+- A partial focused proposal could hide downstream effects; preserve unaffected sections and require
+  a complete current-state document on every approved write.
+- Consumers might accidentally become writers as workflows evolve; contract tests and the explicit
+  exclusive-ownership boundary prevent implicit creation or mutation.
+- The brief can become stale; focused updates retain a deliberate human approval point while
+  avoiding an append-only history that obscures the current product decision.

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -147,10 +147,20 @@ test("product-brief consumers preserve read-only ownership and pause for approve
   const newProject = readRelative("skills/new-project/SKILL.md").replace(/\s+/g, " ");
   assert.match(newProject, /greenfield.*?missing.*?docs\/product\.md.*?\$product-discovery.*?initial adaptive discovery.*?explicit human approval.*?(?:before|prior to).*?stack selection/i, "greenfield scaffolding discovers an approved brief before choosing a stack");
   assert.match(newProject, /existing repositor(?:y|ies).*?(?:must not|never|do not).*?(?:create|edit|write).*?docs\/product\.md/i, "existing repositories do not implicitly gain a brief");
+  assert.match(newProject, /docs\/product\.md.*?exists.*?read.*?approved brief.*?product context.*?informs.*?stack.*?scaffolding/i, "an existing approved brief informs stack and scaffolding decisions");
+
+  const roadmap = readRelative("skills/roadmap-planning/SKILL.md").replace(/\s+/g, " ");
+  assert.match(roadmap, /MVP hypothesis.*?core user journeys.*?non-goals.*?success criteria.*?bound.*?milestones.*?epics.*?stories/i, "roadmaps are bounded by every required product-brief dimension");
+
+  const refiner = readRelative("skills/refine-issues/SKILL.md").replace(/\s+/g, " ");
+  assert.match(refiner, /proposed story.*?fits.*?approved direction/i, "refinement checks a story against approved product direction");
 
   const spec = readRelative("skills/spec/SKILL.md").replace(/\s+/g, " ");
   assert.match(spec, /new.*?(?:read|consume).*?docs\/product\.md/i, "new technical contracts consume a present brief");
   assert.match(spec, /(?:list|link|status).*?(?:continue|do not block|compatible).*?(?:without|missing|absent).*?(?:brief|docs\/product\.md)/i, "administrative spec operations remain available without a brief");
+
+  const conventions = readRelative("skills/spec-conventions/SKILL.md").replace(/\s+/g, " ");
+  assert.match(conventions, /docs\/product\.md.*?exists.*?before.*?brainstorming.*?feature work.*?significant design/i, "product context is applied before brainstorming, feature work, and significant design");
 });
 
 test("README documents the durable product-discovery workflow", () => {

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -125,6 +125,45 @@ test("product-discovery defines the portable, approval-gated product brief contr
   assert.doesNotMatch(skill, /CLAUDE_PLUGIN_ROOT|PLUGIN_ROOT|hooks\/|commands\//i, "skill stays portable");
 });
 
+test("product-brief consumers preserve read-only ownership and pause for approved rediscovery", () => {
+  const consumers = [
+    { name: "new-project", path: "skills/new-project/SKILL.md" },
+    { name: "roadmap-planning", path: "skills/roadmap-planning/SKILL.md" },
+    { name: "refine-issues", path: "skills/refine-issues/SKILL.md" },
+    { name: "spec", path: "skills/spec/SKILL.md" },
+    { name: "spec-conventions", path: "skills/spec-conventions/SKILL.md" },
+  ];
+
+  for (const consumer of consumers) {
+    const skill = readRelative(consumer.path);
+    const normalized = skill.replace(/\s+/g, " ");
+
+    assert.match(normalized, /(?:read|consume).*?`?docs\/product\.md`?.*(?:brief|context)|(?:brief|context).*?(?:read|consume).*?`?docs\/product\.md`?/i, `${consumer.name} reads a present brief`);
+    assert.match(normalized, /(?:missing|without|absent).*?(?:brief|docs\/product\.md).*?(?:continue|compatible|normal)|(?:continue|compatible|normal).*?(?:missing|without|absent).*?(?:brief|docs\/product\.md)/i, `${consumer.name} remains compatible when the brief is absent`);
+    assert.match(normalized, /(?:must not|never|do not).*?(?:create|edit|write|mutate).*?`?docs\/product\.md`?/i, `${consumer.name} never takes ownership of the brief`);
+    assert.match(normalized, /durable contradiction.*?pause.*?\$product-discovery.*?focused.*?(?:update|rediscovery).*?explicit human approval.*?resume/i, `${consumer.name} pauses for approved focused rediscovery`);
+  }
+
+  const newProject = readRelative("skills/new-project/SKILL.md").replace(/\s+/g, " ");
+  assert.match(newProject, /greenfield.*?missing.*?docs\/product\.md.*?\$product-discovery.*?initial adaptive discovery.*?explicit human approval.*?(?:before|prior to).*?stack selection/i, "greenfield scaffolding discovers an approved brief before choosing a stack");
+  assert.match(newProject, /existing repositor(?:y|ies).*?(?:must not|never|do not).*?(?:create|edit|write).*?docs\/product\.md/i, "existing repositories do not implicitly gain a brief");
+
+  const spec = readRelative("skills/spec/SKILL.md").replace(/\s+/g, " ");
+  assert.match(spec, /new.*?(?:read|consume).*?docs\/product\.md/i, "new technical contracts consume a present brief");
+  assert.match(spec, /(?:list|link|status).*?(?:continue|do not block|compatible).*?(?:without|missing|absent).*?(?:brief|docs\/product\.md)/i, "administrative spec operations remain available without a brief");
+});
+
+test("README documents the durable product-discovery workflow", () => {
+  const readme = readRelative("README.md").replace(/\s+/g, " ");
+
+  assert.match(readme, /greenfield.*?(?:before|prior to).*?(?:stack selection|scaffolding).*?\$?product-discovery/i);
+  assert.match(readme, /only.*?product-discovery.*?(?:create|write|strategic(?:ally)? update).*?docs\/product\.md/i);
+  assert.match(readme, /existing repositor(?:y|ies).*?(?:without|missing).*?(?:brief|docs\/product\.md).*?(?:continue|compatible)/i);
+  assert.match(readme, /read-only.*?(?:roadmap|refin(?:e|ement)|spec|design|feature)/i);
+  assert.match(readme, /durable contradiction.*?focused.*?(?:rediscovery|update).*?explicit human approval/i);
+  assert.doesNotMatch(readme, /product.discovery[\s\S]{0,100}(?:hook|script|dependency|command)/i, "product-discovery documentation stays portable");
+});
+
 test("workflow-risk is a portable, issue-linked FAST/STANDARD/CRITICAL contract", () => {
   const skillPath = "skills/workflow-risk/SKILL.md";
   assert.ok(existsSync(join(repoRoot, skillPath)), `${skillPath} exists`);

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -105,9 +105,17 @@ test("product-discovery defines the portable, approval-gated product brief contr
   assert.match(normalized, /trade-offs?/i);
   assert.match(normalized, /recommendation/i);
   assert.match(normalized, /challenge.*?scope.*?MVP hypothesis|MVP hypothesis.*?challenge.*?scope/i);
-  assert.match(normalized, /complete|full.*?visible proposal/i);
+  assert.match(
+    normalized,
+    /(?:complete|full).*?visible proposal.*?(?:before|prior to).*?(?:creating|create|writing|write|updating|update)/i,
+    "a complete visible proposal precedes a durable write"
+  );
   assert.match(normalized, /explicit human approval.*?(?:before|prior to).*?(?:create|write|update)|(?:create|write|update).*?only after.*?explicit human approval/i);
-  assert.match(normalized, /unapproved|declined.*?(?:leave|keep).*?unchanged/i);
+  assert.match(
+    normalized,
+    /(?:write.*?only after.*?explicit human approval|do not write.*?until approval).*?(?:declined|unapproved).*?(?:leave|keep).*?unchanged/i,
+    "approval gating links a no-write condition to unchanged durable state"
+  );
   assert.match(normalized, /focused update.*?only.*?affected decisions/i);
   assert.match(normalized, /preserv.*?unaffected.*?sections/i);
   assert.match(normalized, /rewrite|replacement.*?current.state/i);

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -58,6 +58,65 @@ function parseFrontmatter(markdown) {
   );
 }
 
+test("product-discovery defines the portable, approval-gated product brief contract", () => {
+  const skillPath = "skills/product-discovery/SKILL.md";
+  const templatePath = "skills/product-discovery/assets/product.md";
+  const metadataPath = "skills/product-discovery/agents/openai.yaml";
+  assert.ok(existsSync(join(repoRoot, skillPath)), `${skillPath} exists`);
+  assert.ok(existsSync(join(repoRoot, templatePath)), `${templatePath} exists`);
+  assert.ok(existsSync(join(repoRoot, metadataPath)), `${metadataPath} exists`);
+
+  const skill = readRelative(skillPath);
+  const template = readRelative(templatePath);
+  const metadata = readRelative(metadataPath);
+  const frontmatter = parseFrontmatter(skill);
+  const normalized = skill.replace(/\s+/g, " ");
+
+  assert.equal(frontmatter.name, "product-discovery");
+  assert.match(frontmatter.description, /^Use when/);
+  assert.match(frontmatter.description, /product|discovery|brief/i);
+  assert.match(metadata, /display_name:/);
+  assert.match(metadata, /short_description:/);
+  assert.match(metadata, /default_prompt:/);
+
+  const canonicalSections = [
+    "Target user",
+    "Core problem",
+    "Current alternative",
+    "Value proposition",
+    "MVP hypothesis",
+    "Core user journeys",
+    "Non-goals",
+    "Success criteria",
+    "Product principles and constraints",
+  ];
+  const templateSections = [...template.matchAll(/^## (.+)$/gm)].map((match) => match[1]);
+  assert.deepEqual(templateSections, canonicalSections, "template has exactly the canonical sections in order");
+  assert.equal((template.match(/^# Product brief$/gm) ?? []).length, 1, "template has one title");
+
+  assert.match(normalized, /initial adaptive discovery/i);
+  assert.match(normalized, /focused (?:strategic )?update/i);
+  assert.match(normalized, /read-only (?:consumption )?mode/i);
+  assert.match(normalized, /only .*?product-discovery.*?(?:may|is authorized to).*(?:create|write|strategic(?:ally)? update).*?`?docs\/product\.md`?/i);
+  assert.match(normalized, /conversation.*?(?:repository|context)|repository.*?conversation.*?context/i);
+  assert.match(normalized, /material assumptions?.*?(?:visible|label)|(?:visible|label).*?material assumptions?/i);
+  assert.match(normalized, /one (?:relevant )?decision at a time/i);
+  assert.match(normalized, /two (?:or three|-to-three|to three)|2.?3 alternatives/i);
+  assert.match(normalized, /trade-offs?/i);
+  assert.match(normalized, /recommendation/i);
+  assert.match(normalized, /challenge.*?scope.*?MVP hypothesis|MVP hypothesis.*?challenge.*?scope/i);
+  assert.match(normalized, /complete|full.*?visible proposal/i);
+  assert.match(normalized, /explicit human approval.*?(?:before|prior to).*?(?:create|write|update)|(?:create|write|update).*?only after.*?explicit human approval/i);
+  assert.match(normalized, /unapproved|declined.*?(?:leave|keep).*?unchanged/i);
+  assert.match(normalized, /focused update.*?only.*?affected decisions/i);
+  assert.match(normalized, /preserv.*?unaffected.*?sections/i);
+  assert.match(normalized, /rewrite|replacement.*?current.state/i);
+  assert.match(normalized, /not.*?(?:append|journal|history)|(?:append|journal|history).*?not/i);
+  assert.match(normalized, /without.*?brief.*?read-only|read-only.*?without.*?brief/i);
+  assert.match(normalized, /must not create.*?implicitly|never.*?create.*?implicitly/i);
+  assert.doesNotMatch(skill, /CLAUDE_PLUGIN_ROOT|PLUGIN_ROOT|hooks\/|commands\//i, "skill stays portable");
+});
+
 test("workflow-risk is a portable, issue-linked FAST/STANDARD/CRITICAL contract", () => {
   const skillPath = "skills/workflow-risk/SKILL.md";
   assert.ok(existsSync(join(repoRoot, skillPath)), `${skillPath} exists`);


### PR DESCRIPTION
## At a glance

Projects can now capture an approved, durable product brief before greenfield scaffolding and use
that context consistently across planning workflows. Maintainers gain a portable, approval-gated
`plus-ultra:product-discovery` skill without disrupting existing repositories that have no brief.

## Diagram

```mermaid
flowchart LR
  D[product-discovery] --> B[docs/product.md]
  B --> N[new-project]
  B --> R[roadmap-planning]
  B --> I[refine-issues]
  B --> S[spec]
  B --> C[spec-conventions]
```

## Context

Issue #36 needs a durable product direction that remains explicit across product and technical
planning, while preserving human approval for new or strategically changed decisions.

## Traceability

- Issue: #36
- Spec: `specs/010-add-durable-product-brief.md` (approved)
- Refs #36

## Summary

- Add the portable, sole-writer `plus-ultra:product-discovery` skill and canonical nine-section
  product brief template.
- Gate greenfield stack/scaffold decisions on approved discovery and add read-only context to
  roadmap, issue refinement, specs, and significant design/feature workflows.
- Add contract coverage and document ownership, compatibility, and contradiction rediscovery.

## Testing

- `node --test tests/skills.test.mjs` — 27 passing
- `node --test tests/*.test.mjs` — 130 passing
- `node scripts/validate-packaging.mjs .` — passed
- `claude plugin validate .` — passed
- Clean temporary `CODEX_HOME`: marketplace add and `plus-ultra` plugin install — passed
- `git diff --check` — passed

## Risks

- Existing repositories remain compatible without implicit `docs/product.md` creation; teams adopt
  discovery when they want durable product context.

## Review Guidance

- Confirm `product-discovery` remains the only writer and requires explicit approval before writes.
- Check the exact template headings/order and consumer behavior for absent briefs and durable
  contradictions.
