### PR TITLE
feat(design-artifacts): add Pencil-backed design lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,39 @@ When proposed work creates a durable contradiction with the brief, pause that wo
 focused rediscovery update through `$product-discovery`. Resume only after the resulting update
 has explicit human approval.
 
+## Design artifacts
+
+Use `plus-ultra:design-artifacts` when creating, resolving, approving, reviewing, or revising visual
+designs for Issues, or maintaining the reusable design system. Each design is the durable pair
+`designs/NNN-slug.md` + `designs/NNN-slug.pen`. The manifest records title, status, explicit `issues`,
+the paired Pencil path, surface IDs/names, creation date, and optional `supersedes` sequence.
+List the epic, when applicable, and every covered story in `issues`; hierarchy never implies
+coverage. One pair can describe a journey shared by several explicitly listed stories.
+
+The lifecycle is `draft → approved → superseded`. Approval requires the saved paired file to be
+active in Pencil, verified surface IDs, captures shown for review, and explicit human approval of
+that exact pair. A revision creates the next numbered draft with `supersedes`; the old pair stays
+approved until the replacement is approved. Only then does its manifest become superseded; the
+old `.pen` is preserved unchanged.
+
+Resolution uses exact Issue membership among approved manifests. One match selects its manifest,
+Pencil path, and surfaces; zero returns `none`; multiple return `ambiguous` and pause dependent work
+for explicit human selection. Recency and filenames never choose a winner. Review is read-only
+and reports evidence and findings without approving or repairing the design.
+
+Root `DESIGN.md` contains reusable principles, primitive/semantic/component tokens, typography,
+color, spacing and density, components and states, responsive behavior, motion, and accessibility.
+Its template keeps these system rules separate from concrete screens in `.pen` pairs. Show a
+concrete proposal and obtain explicit human approval before creating or updating `DESIGN.md`;
+that approval does not approve or rewrite a screen pair.
+
+Pencil/pen.dev is optional and external. When it is unavailable, the wrong file is open, or a
+surface cannot be verified, pause the affected visual authoring, review, or approval; existing
+artifact resolution and independent nonvisual work continue. The skill consumes a present
+`docs/product.md` read-only, continues when it is absent, and routes durable contradictions through
+approved product discovery. UI-impact classification (#35), browser verification (#24), and
+workflow orchestration (#22) remain separate concerns.
+
 ## Optional companions
 
 `plus-ultra` stays focused on spec-driven development. For day-to-day projects, it pairs well with
@@ -211,6 +244,8 @@ sandbox. There is no `plus-ultra:integrate` command.
     `--spec <NNN|slug>` as a fallback. This workflow requires GitHub write access through `gh`.
   - *integration-boundary* — portable policy for ending autonomous work at ready for integration;
     manual merge and publication remain human-owned.
+  - *design-artifacts* — numbered Issue-linked Pencil design pairs with explicit human approval,
+    deterministic resolution, preserved revisions, read-only review, and reusable `DESIGN.md` rules.
   - *workflow-risk* — portable FAST / STANDARD / CRITICAL classification contract. It records
     explainable initial and pre-ship recommendations without commands, hooks, or state: Issue #22
     owns future orchestration and persistence, Issue #26 owns conditional Semgrep execution, and

--- a/skills/design-artifacts/SKILL.md
+++ b/skills/design-artifacts/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: design-artifacts
+description: Use when creating, resolving, approving, or reviewing durable visual design artifacts for Issues, revising an approved Pencil design, or maintaining DESIGN.md.
+---
+
+# plus-ultra:design-artifacts
+
+Keep visual decisions in numbered design pairs and reusable design rules in `DESIGN.md`.
+Pencil (pen.dev) is an optional external capability. This skill defines artifact ownership and
+lifecycle; UI-impact classification belongs to Issue #35, browser verification to #24, and workflow
+orchestration to #22.
+
+## Product context
+
+When `docs/product.md` exists, read it as read-only product context before design work. When it is
+absent, continue normally and never create it implicitly. Do not create, edit, or append to
+`docs/product.md` in this workflow.
+
+If proposed work creates a durable contradiction with that brief—both cannot materially remain
+true—pause the affected workflow and route to `plus-ultra:product-discovery` for a focused strategic
+update. Only after the resulting update has explicit human approval, resume. Implementation-level
+choices remain here; they do not grant ownership of product direction.
+
+## Artifact contract
+
+One design is the pair `designs/NNN-slug.md` + `designs/NNN-slug.pen`, committed together as durable
+project artifacts. Allocate the highest existing number across both file types and add one,
+zero-padded to at least three digits. Start at `001`; never reuse a number or overwrite a pair.
+Use [`assets/design-artifact.md`](./assets/design-artifact.md) for the manifest and replace all
+example values before review.
+
+```text
+DesignStatus = draft | approved | superseded
+
+DesignArtifactManifest = {
+  title: string
+  status: DesignStatus
+  issues: PositiveInteger[]
+  pencil: RelativePenPath
+  surfaces: { id: PencilNodeId, name: string }[]
+  created: YYYY-MM-DD
+  supersedes?: "NNN"
+}
+
+DesignResolution =
+  | { result: selected, manifest, pencil, surfaces }
+  | { result: none }
+  | { result: ambiguous, candidates }
+```
+
+`title` is nonempty. `issues` is a nonempty list of distinct positive integers from the current
+repository. Explicitly enumerate the epic, when applicable, and every covered story. Never infer
+coverage from remote hierarchy, an epic link, a filename, or prose. A shared journey may cover
+multiple stories in one pair.
+
+`pencil` is relative to the manifest's directory and points to its same-stem sibling, for example
+`./001-checkout.pen`. Reject absolute paths, traversal (`..`), paths escaping through symlinks,
+and mismatched stems. Require nonempty `surfaces` with unique IDs: each `id` is an opaque, nonempty
+Pencil node ID, and each `name` is a human-readable surface name. `created` is a real calendar date
+in `YYYY-MM-DD` format. Optional `supersedes` is the quoted sequence of the prior pair, such as
+`"001"`, not an Issue number; the prior pair must exist and be explicitly identified.
+
+## Resolve an Issue
+
+Resolution is read-only and does not require Pencil. Given a positive Issue number, inspect local
+`designs/*.md` frontmatter. Consider only `approved` manifests with an exact integer match in
+`issues`; ignore `draft` and `superseded` manifests. Do not traverse remote Issue hierarchy.
+
+| Match count | Result and next action |
+| --- | --- |
+| Zero matches | Return `{ result: none }`; continue work that does not depend on an approved visual design. Do not create an artifact or select a draft as a fallback. |
+| One match | Return `selected` with the manifest path, resolved `pencil` path, and declared `surfaces`. Selection identifies the existing approval; it does not claim fresh visual verification. |
+| Multiple matches | Return `ambiguous` with all candidates: manifest paths, titles, Pencil paths, and surfaces. Pause dependent work for explicit human selection of a candidate. |
+
+Never guess or choose by recency, filename, file order, or apparent specificity. A selection resolves
+only this request; it does not change approval status or supersede another candidate. Report
+malformed manifests or broken paired paths as validation problems and pause affected consumption;
+do not silently discard them to manufacture `none` or a unique match. Live surface verification
+belongs to visual review, so an unavailable editor alone does not block local resolution.
+
+## Pencil capability
+
+Inspect available tool definitions for `get_app_state` and `execute`; use their current schemas.
+`get_app_state` identifies the active document. Within `execute`, `Get` reads nodes and
+`TakeScreenshot` captures surfaces; use the advertised operations for draft node manipulation.
+Check `get_app_state` before every mutation or visual verification and ensure the active document
+is the intended `.pen` at its resolved path. Node names alone cannot establish file identity.
+Save the draft to its paired path before review; verify that the saved file and reviewed document
+correspond.
+
+If Pencil is unavailable, required operations are missing, or the wrong file is open, pause only
+visual authoring, review, or approval. Explain the missing capability or exact file that must be
+opened. Existing-artifact resolution and independent nonvisual work continue, including reading
+manifests, product context, and reusable `DESIGN.md` rules. Do not fabricate screenshots or claim
+visual verification. Missing surface IDs likewise block the affected visual check; inspect the
+correct document before proposing a repair to a draft.
+
+Tool behavior is documented in [Pencil AI integration](https://docs.pencil.dev/getting-started/ai-integration).
+See [Pencil files](https://docs.pencil.dev/core-concepts/pen-files) for the versionable `.pen` format
+and saving workflow. These are external capabilities, not installation requirements of this skill.
+
+## Create a draft
+
+Read product context and an existing `DESIGN.md`, identify the explicit Issue coverage, and allocate
+the next pair. A new design always starts in `draft`. Author its `.pen` through Pencil after the
+active-file check, recording the actual surface IDs and names in the manifest. Do not populate
+IDs from guesses or leave template placeholders as purported evidence. Describe scoped visual
+decisions in the manifest body, with reusable rules referenced from `DESIGN.md`.
+
+When visual authoring is blocked, text preparation may continue as clearly incomplete draft work;
+do not claim the pair is complete until its saved `.pen` exists and its surfaces are verified.
+
+## Approve a draft
+
+1. Validate all manifest fields, explicit Issue coverage, and the existing saved `.pen` path.
+2. Use `get_app_state` to verify the active file path matches that paired `.pen`.
+3. Use `execute` with `Get` to verify every surface ID exists in that document, then
+   `TakeScreenshot` for every surface. Inspect the captures against the stated design intent and
+   applicable `DESIGN.md` rules. A missing surface or failed capture pauses approval; never invent
+   a replacement ID or evidence.
+4. Show the proposed manifest, Issue coverage, and surface captures together, naming the exact pair
+   and any replacement. Resolve review findings before asking for a decision.
+5. Only explicit human approval of that reviewed pair permits changing `status` to `approved`.
+   An implementation request, plan approval, successful check, or agent recommendation is not design
+   approval. A declined or unapproved proposal remains `draft`, with lifecycle state unchanged.
+
+Approval applies to the reviewed version. Edits after review require renewed verification and an
+explicit decision on the changed version. Record concise review evidence in the manifest body,
+including the actual human decision when given; do not invent approvers or timestamps.
+
+## Revise an approved design
+
+Create the next numbered pair as `draft`; set `supersedes` to the previous pair's `NNN`. Copy the
+prior `.pen` to the new path before editing, then confirm the new draft is active in Pencil.
+Never modify an approved `.pen`, even for a small correction. Preserve the prior manifest's
+coverage, surface declarations, and evidence during drafting; express proposed changes in the new
+manifest. The prior pair remains approved until the replacement is approved.
+
+Use the full approval workflow for the revision. Only after explicit human approval of the new
+pair, mark the new manifest `approved` and the referenced prior manifest `superseded` as the same
+lifecycle update. The old `.pen` stays unchanged. If the proposal is declined or unapproved, the
+prior pair stays unchanged and the revision stays draft. If a lifecycle write is interrupted,
+report the incomplete transition; multiple approved matches still resolve as ambiguous. No
+implicit deletion, coverage transfer, or retirement of other approved pairs is allowed.
+
+## Review a design
+
+Review is read-only: inspect the manifest's Issue coverage, paired path, surface IDs and captures,
+and applicable `DESIGN.md` rules using the Pencil checks above. Report each finding with its
+manifest path and surface ID, observed evidence, and required change. Separate verified findings
+from incomplete checks. With unavailable Pencil or missing evidence, report visual review as
+incomplete, identifying what remains unverified; independent text review may continue.
+
+Do not edit the pair, approve it, or change status during review. A requested fix to an approved
+pair enters the revision workflow. Review output is evidence for a human decision, not approval.
+Browser-based implementation verification remains the separate concern of Issue #24.
+
+## Maintain DESIGN.md
+
+The root-level `DESIGN.md` holds reusable principles, rules, tokens, and component behavior. Start
+from [`assets/DESIGN.md`](./assets/DESIGN.md); retain its canonical heading order and three token
+layers: primitive values → semantic roles → component uses. Document typography, color, spacing
+and density, components and states, responsive behavior, motion, and accessibility at system level.
+Do not duplicate concrete screen layouts from `.pen` files here; exact screens and journey-specific
+decisions stay with their numbered pair.
+
+For creation or a requested system update, show a concrete proposal and obtain explicit human
+approval before writing or updating `DESIGN.md`. Preserve unaffected rules in an update. A declined
+or unapproved proposal leaves an existing file unchanged and a missing file absent. A text-only
+system update may proceed without Pencil when its evidence is available; state any unverified
+visual implications. Approval of `DESIGN.md` does not approve a numbered artifact or authorize
+editing approved `.pen` files. If new system rules conflict with an approved design, report that
+conflict for an explicit revision or system decision instead of silently reconciling either file.
+
+## Resolution examples
+
+| Case | Issue and local manifests | Result |
+| --- | --- | --- |
+| Single story | Issue 184; `001` approved with `issues: [184]` | `selected` with `001` manifest, Pencil path, and surfaces |
+| Shared journey | Issue 185; `002` approved with `issues: [180, 184, 185]` | `selected` with `002`; Issue 184 selects that same journey when it is the only match |
+| Excluded statuses | Issue 184; `001` draft and `002` superseded, both list 184 | `none` |
+| No match | Issue 186; `002` approved with `issues: [180, 184, 185]` | `none`; no inferred child coverage |
+| Ambiguous | Issue 184; `001` approved and `002` approved, both list 184 | `ambiguous` with both candidates; wait for explicit selection |

--- a/skills/design-artifacts/agents/openai.yaml
+++ b/skills/design-artifacts/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Design Artifacts"
+  short_description: "Manage approved visual artifacts and reusable design rules"
+  default_prompt: "Use $design-artifacts to create, resolve, approve, review, or revise design artifacts and DESIGN.md."
+policy:
+  allow_implicit_invocation: true

--- a/skills/design-artifacts/assets/DESIGN.md
+++ b/skills/design-artifacts/assets/DESIGN.md
@@ -1,0 +1,49 @@
+# Design system
+
+## Principles
+
+<Reusable visual and interaction principles aligned with the approved product direction.>
+
+## Tokens
+
+### Primitive tokens
+
+<Named raw values: palette, sizes, spacing, radii, shadows, and durations. Include units.>
+
+### Semantic tokens
+
+<Role-based aliases to primitives: surfaces, content, actions, borders, feedback, and themes.>
+
+### Component tokens
+
+<Component-specific aliases to semantic roles, including relevant variants and states.>
+
+## Typography
+
+<Font families and fallbacks, size and line-height scales, weights, hierarchy, and reading widths.>
+
+## Color
+
+<Semantic color usage, themes, contrast expectations, and non-color indicators. Reference tokens.>
+
+## Spacing and density
+
+<Spacing rhythm, grouping, touch targets, and supported density modes. Reference tokens.>
+
+## Components and states
+
+<Reusable component anatomy, variants, and interaction rules. Cover applicable default, hover,
+focus, active, disabled, loading, empty, error, and success states.>
+
+## Responsive behavior
+
+<Breakpoint rationale, fluid behavior, reflow, content priority, and input-modality adaptation.>
+
+## Motion
+
+<Purpose, durations, easing, transitions, and reduced-motion behavior. Reference tokens.>
+
+## Accessibility
+
+<Keyboard behavior, focus visibility/order, semantics, accessible names, contrast, and alternatives
+to visual or motion-only communication. Keep concrete screens in their numbered .pen pairs.>

--- a/skills/design-artifacts/assets/design-artifact.md
+++ b/skills/design-artifacts/assets/design-artifact.md
@@ -1,0 +1,35 @@
+---
+title: <Design title>
+status: draft
+issues: [100, 101, 102] # Replace with the explicit epic (if applicable) and every covered story.
+pencil: ./NNN-slug.pen
+surfaces:
+  - id: <actual-pencil-node-id>
+    name: <Human-readable surface name>
+created: <YYYY-MM-DD>
+# supersedes: "NNN"
+---
+
+# NNN — <Design title>
+
+## Scope and Issue coverage
+
+<Describe the journey or story boundary. Map every listed Issue to its covered surfaces or steps.
+Do not infer coverage for an unlisted story from its parent epic.>
+
+## Surfaces
+
+<Describe the intended purpose, viewport, and state of each declared surface. Frontmatter IDs must
+come from the saved paired Pencil document; names and template placeholders are not valid IDs.>
+
+## Visual decisions
+
+<Record the concrete layout and journey decisions represented by this pair. Reference applicable
+root DESIGN.md rules; keep reusable tokens and component rules in that file.>
+
+## Review evidence
+
+<Before approval: identify the saved paired file and verified active document, each checked surface
+ID, and the captures shown for human review. State missing checks as incomplete. Record findings
+and their resolution. After explicit human approval, record the actual decision for this exact
+reviewed pair; do not manufacture evidence or treat a plan approval as design approval.>

--- a/specs/011-define-pencil-backed-design-artifacts.md
+++ b/specs/011-define-pencil-backed-design-artifacts.md
@@ -1,0 +1,167 @@
+---
+title: Define Pencil-backed design artifacts
+status: approved
+issue: 16
+created: 2026-09-07
+---
+
+# 011 — Define Pencil-backed design artifacts
+
+## Problem
+
+Visual design decisions need a durable, reviewable source of truth linked to the Issues they
+cover. Without an explicit artifact contract, agents can guess between competing designs, edit an
+approved design in place, infer story coverage from an epic, or block unrelated work when a visual
+tool is unavailable. Reusable design-system rules also need a clear boundary from concrete screens.
+
+## Goals / Non-goals
+
+**Goals**
+
+- Add the portable `plus-ultra:design-artifacts` skill with manifest and design-system templates.
+- Define creation, deterministic Issue resolution, explicit human approval, read-only review, and
+  revision for durable Pencil-backed design pairs.
+- Keep reusable current design rules in root `DESIGN.md`, separate from concrete `.pen` screens.
+- Consume a present `docs/product.md` without taking ownership of it.
+- Treat Pencil/pen.dev as an optional external capability with a narrowly scoped visual pause.
+
+**Non-goals**
+
+- Add commands, hooks, scripts, dependencies, manifest changes, or platform-specific mechanisms.
+- Classify UI impact (Issue #35), implement browser verification (Issue #24), or orchestrate
+  workflows and persistent execution state (Issue #22).
+- Infer Issue coverage through remote hierarchy, replace technical specs or Issue progress, or
+  automatically approve, merge, publish, tag, or release anything.
+
+## Acceptance criteria
+
+- [x] The portable `skills/design-artifacts/SKILL.md` ships with both templates and coherent
+      `agents/openai.yaml` metadata enabling implicit invocation, without new platform surfaces.
+- [x] Each design is a same-stem `designs/NNN-slug.md` / `designs/NNN-slug.pen` pair using the
+      typed manifest below and explicit epic/story coverage; no hierarchy inference is allowed.
+- [x] Resolution uses only approved exact Issue matches: one selects the manifest, Pencil path,
+      and surfaces; zero returns `none`; multiple return `ambiguous` and require explicit selection.
+- [x] A new design starts draft. Approval validates the saved `.pen`, active file, actual surface
+      IDs and captures, and requires explicit human approval of the reviewed pair.
+- [x] Revision creates the next numbered draft pair with `supersedes`. The prior pair stays
+      approved until explicit approval of the replacement; then its manifest becomes superseded
+      and its `.pen` remains unchanged.
+- [x] Read-only review reports observed evidence and actionable findings without editing the pair
+      or changing approval state; incomplete visual checks remain explicitly unverified.
+- [x] Root `DESIGN.md` has the canonical principles, three token layers, typography, color, spacing
+      and density, components and states, responsive, motion, and accessibility sections. It holds
+      reusable rules, does not duplicate screens, and its writes require explicit human approval.
+- [x] A present `docs/product.md` is read-only context. Its absence permits normal continuation;
+      durable contradictions pause for product-discovery and resume only after approved updating.
+- [x] Pencil tools `get_app_state` and `execute` verify the active document, manipulate draft nodes,
+      and capture surfaces. Unavailable tools, a wrong active file, or missing surfaces pause the
+      affected visual work; artifact resolution and independent nonvisual work continue.
+- [x] README documents the portable workflow, lifecycle, exact resolution, design-system boundary,
+      and optional Pencil behavior. Contract and isolated forward tests cover the stated scenarios.
+
+## Interface contracts
+
+```text
+DesignStatus = draft | approved | superseded
+
+DesignArtifactManifest = {
+  title: string
+  status: DesignStatus
+  issues: PositiveInteger[]
+  pencil: RelativePenPath
+  surfaces: { id: PencilNodeId, name: string }[]
+  created: YYYY-MM-DD
+  supersedes?: "NNN"
+}
+
+DesignResolution =
+  | { result: selected, manifest, pencil, surfaces }
+  | { result: none }
+  | { result: ambiguous, candidates }
+```
+
+Manifest files use YAML frontmatter. `title`, `issues`, and `surfaces` are nonempty. Issue numbers
+are distinct positive integers for the current repository and enumerate the epic, if applicable,
+and all covered stories. Surface IDs are unique opaque Pencil node IDs with human-readable names.
+The date is a real `YYYY-MM-DD` creation date. `pencil` is a relative same-stem sibling path resolved
+from the manifest directory; absolute, traversal, escaping symlink, and mismatched paths are
+invalid. `supersedes` identifies an existing prior pair's quoted sequence.
+
+Numbering starts at `001`, uses at least three digits, and increments the highest number across
+both file types. Creation never reuses a number. A revision copies the previous `.pen` into the
+next pair before editing and preserves the prior manifest during drafting. After reviewed human
+approval, the new manifest becomes approved and only the referenced prior manifest becomes
+superseded. Declined or unapproved replacements leave the old pair unchanged.
+
+Resolution is a local read-only operation over approved manifests listing the exact requested
+Issue. It returns `none`, `selected`, or `ambiguous` according to match count. Ambiguity lists all
+candidates and pauses dependent work until explicit human selection, never choosing by recency,
+name, or order. Selection itself changes no lifecycle state. Invalid manifests or broken paths
+are reported and pause affected consumption rather than being silently filtered out. Local
+resolution does not claim that live surface checks have run.
+
+Approval checks the saved paired path, matches `get_app_state` to the intended active file, uses
+`execute` / `Get` for every surface ID, captures each surface through `TakeScreenshot`, and shows
+the manifest, coverage, and captures for an explicit human decision on that exact version. Request
+or plan approval does not approve a design. Changes after review require renewed verification.
+
+Root `DESIGN.md` follows `assets/DESIGN.md` in this order: Principles; Tokens (Primitive tokens,
+Semantic tokens, Component tokens); Typography; Color; Spacing and density; Components and states;
+Responsive behavior; Motion; Accessibility. Creation and updates show a concrete proposal and
+require explicit human approval before writing, preserving unaffected rules. Approval of reusable
+rules does not approve a screen pair or authorize changing approved `.pen` files.
+
+## Architecture boundaries
+
+The skill owns artifact conventions and interaction policy. The manifest owns Issue linkage,
+lifecycle, and pointers to concrete surfaces; its paired `.pen` owns visual decisions. `DESIGN.md`
+owns reusable system rules. Only `plus-ultra:product-discovery` owns the durable product brief.
+Pencil is the external visual editing and inspection boundary; no bundled runtime adapter is added.
+UI classification, browser checks, and orchestration stay with #35, #24, and #22 respectively.
+
+## Functional core
+
+Resolution is a deterministic policy over local manifest status and explicit Issue membership.
+Its conceptual results are selected, none, and ambiguous; no executable resolver is introduced.
+Reading files, editing a draft through Pencil, capturing surfaces, receiving human approval, and
+writing lifecycle changes are explicit side effects. Review and resolution remain read-only.
+An unavailable editor affects visual work only. Human approval is explicit input and cannot be
+derived from successful checks, a prior plan, an agent recommendation, or a lack of response.
+
+## Data model
+
+Durable artifacts are numbered Markdown/Pencil pairs plus root `DESIGN.md`. The manifest template
+adds body sections for Scope and Issue coverage, Surfaces, Visual decisions, and Review evidence.
+The body documents observed checks and the actual human decision without inventing a separate
+approval state store. Only draft pairs are editable; the prior manifest's superseded transition
+is the sole change to an approved pair when its replacement is approved. Existing history remains
+readable. There are no database migrations, new dependencies, or manifest schema changes.
+
+## Test plan
+
+- Add contractual tests before production files and run `node --test tests/skills.test.mjs` to
+  observe RED for missing files and guidance. Confirm GREEN after implementation.
+- Verify frontmatter, metadata, manifest fields, exact template headings, approved spec #011,
+  README workflow, portability, and absence of new platform-specific surfaces.
+- Cover a single approved story, a shared approved journey with explicit stories, ignored draft
+  and superseded manifests, no exact match, and ambiguity requiring explicit selection.
+- Cover preserved prior approval during revision, full approval evidence, absent Pencil, wrong
+  active file, missing surfaces, absent/present/contradictory product context, read-only review,
+  and the separation of `DESIGN.md` rules from concrete screen decisions.
+- Use isolated forward scenarios before and after implementation to check no guessed selection,
+  no mutation of approved artifacts, and continuation of nonvisual work without Pencil.
+- Run the focused and full Node suites, packaging validation, available Claude validation,
+  clean temporary Codex installation with asset inspection, and `git diff --check` before commit.
+
+## Risks
+
+- Missing or changed Pencil operations can invalidate visual evidence; inspect current schemas,
+  confirm the active file, and explicitly pause affected visual work without claiming success.
+- A saved file can drift from the reviewed document; save and verify the paired file before human
+  approval, and repeat review if the design changes.
+- A partially written supersession can leave two approvals; report the interruption and retain
+  ambiguous resolution until the authorized lifecycle update is completed.
+- New design-system rules can conflict with an approved screen; report the conflict and use an
+  explicit revision or system decision rather than changing the approved screen in place.
+- Written guidance is cooperative, not a runtime enforcement mechanism. Contract tests and
+  independent forward scenarios verify the policy without implying a live Pencil integration test.

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -174,6 +174,198 @@ test("README documents the durable product-discovery workflow", () => {
   assert.doesNotMatch(readme, /product.discovery[\s\S]{0,100}(?:hook|script|dependency|command)/i, "product-discovery documentation stays portable");
 });
 
+function designArtifactFile(path = "SKILL.md") {
+  const relativePath = `skills/design-artifacts/${path}`;
+  assert.ok(existsSync(join(repoRoot, relativePath)), `${relativePath} exists`);
+  return readRelative(relativePath);
+}
+
+test("design-artifacts ships a discoverable portable skill and optional Pencil capability", () => {
+  const skill = designArtifactFile();
+  const frontmatter = parseFrontmatter(skill);
+  const metadata = designArtifactFile("agents/openai.yaml");
+  assert.equal(frontmatter.name, "design-artifacts");
+  assert.match(frontmatter.description, /^Use when/);
+  assert.match(frontmatter.description, /design|Pencil|DESIGN\.md/);
+  assert.match(skill, /plus-ultra:design-artifacts/);
+  assert.match(metadata, /display_name: "Design Artifacts"/);
+  assert.match(metadata, /short_description: ".+"/);
+  assert.match(metadata, /default_prompt: "Use \$design-artifacts /);
+  assert.match(metadata, /policy:\n  allow_implicit_invocation: true/);
+  for (const path of ["SKILL.md", "assets/design-artifact.md", "assets/DESIGN.md"]) {
+    assert.doesNotMatch(designArtifactFile(path), /Claude|Codex|CLAUDE_PLUGIN_ROOT|PLUGIN_ROOT|hooks\/|commands\/|\.claude|\.codex|subagents?/i, `${path} stays portable`);
+  }
+  assert.match(skill.replace(/\s+/g, " "), /Pencil.*?optional.*?external/i);
+  for (const path of ["commands/design-artifacts.md", "hooks/design-artifacts.mjs", "scripts/design-artifacts.mjs"]) {
+    assert.ok(!existsSync(join(repoRoot, path)), `${path} is not introduced`);
+  }
+});
+
+test("design artifacts define typed paired manifests with explicit Issue coverage", () => {
+  const skill = designArtifactFile();
+  const contract = markdownSection(skill, "Artifact contract").replace(/\s+/g, " ");
+  const template = designArtifactFile("assets/design-artifact.md");
+  assert.match(skill, /DesignStatus = draft \| approved \| superseded/);
+  for (const declaration of [
+    "title: string", "status: DesignStatus", "issues: PositiveInteger[]",
+    "pencil: RelativePenPath", "surfaces: { id: PencilNodeId, name: string }[]",
+    "created: YYYY-MM-DD", 'supersedes?: "NNN"',
+  ]) assert.ok(skill.includes(declaration), `manifest declares ${declaration}`);
+  assert.match(contract, /designs\/NNN-slug\.md.*?designs\/NNN-slug\.pen/);
+  assert.match(contract, /highest.*?number.*?add one|maximum.*?number.*?plus one/i);
+  assert.match(contract, /relative to.*?manifest.*?directory/i);
+  assert.match(contract, /(?:no|reject).*?absolute.*?(?:traversal|\.\.)/i);
+  assert.match(contract, /explicitly.*?epic.*?(?:every|all).*?stor(?:y|ies)/i);
+  assert.match(contract, /(?:never|do not).*?infer.*?(?:remote|hierarchy)/i);
+  assert.match(contract, /positive integers/i);
+  assert.match(contract, /nonempty.*?surfaces/i);
+  assert.match(contract, /(?:unique|distinct).*?IDs/i);
+  for (const key of ["title", "status", "issues", "pencil", "surfaces", "created"]) {
+    assert.match(template, new RegExp(`^${key}:`, "m"), `template provides ${key}`);
+  }
+  assert.match(template, /^status: draft$/m);
+  assert.match(template, /^issues: \[100, 101, 102\]/m);
+  assert.match(template, /^pencil: \.\/NNN-slug\.pen$/m);
+  assert.match(template, /^  - id: /m);
+  assert.match(template, /^    name: /m);
+  assert.match(template, /^# supersedes: "NNN"$/m);
+  for (const heading of ["Scope and Issue coverage", "Surfaces", "Visual decisions", "Review evidence"]) {
+    markdownSection(template, heading);
+  }
+});
+
+test("design resolution selects only exact approved Issue matches and never guesses ambiguity", () => {
+  const skill = designArtifactFile();
+  const resolution = markdownSection(skill, "Resolve an Issue").replace(/\s+/g, " ");
+  assert.match(skill, /DesignResolution =/);
+  for (const result of ["{ result: selected, manifest, pencil, surfaces }", "{ result: none }", "{ result: ambiguous, candidates }"]) {
+    assert.ok(skill.includes(result), `resolution declares ${result}`);
+  }
+  assert.match(resolution, /approved.*?exact.*?issues/i);
+  assert.match(resolution, /ignore.*?draft.*?superseded/i);
+  assert.match(resolution, /(?:zero|0) matches.*?none/i);
+  assert.match(resolution, /(?:one|1) match.*?selected.*?manifest.*?pencil.*?surfaces/i);
+  assert.match(resolution, /(?:multiple|two or more) matches.*?ambiguous.*?candidates.*?explicit.*?selection/i);
+  assert.match(resolution, /(?:never|do not).*?(?:guess|choose).*?recency.*?(?:filename|file order)/i);
+  assert.match(resolution, /(?:read-only|without.*?mutat)/i);
+  assert.match(resolution, /(?:without|does not require).*?Pencil/i);
+});
+
+test("design approval requires verified visual evidence and a distinct explicit human decision", () => {
+  const approval = markdownSection(designArtifactFile(), "Approve a draft").replace(/\s+/g, " ");
+  assert.match(approval, /(?:\.pen|pencil).*?(?:exist|saved)/i);
+  assert.match(approval, /get_app_state.*?active.*?(?:path|file).*?(?:match|same)/i);
+  assert.match(approval, /execute.*?Get.*?(?:every|all).*?(?:surface|IDs)/i);
+  assert.match(approval, /TakeScreenshot.*?(?:every|each|all).*?surface/i);
+  assert.match(approval, /(?:show|present).*?(?:manifest|coverage).*?(?:capture|screenshot)/i);
+  assert.match(approval, /only.*?explicit human approval.*?(?:status|approved)/i);
+  assert.match(approval, /(?:request|plan).*?(?:not|never).*?approval/i);
+  assert.match(approval, /(?:declined|unapproved).*?draft.*?(?:unchanged|no.*?transition)/i);
+  assert.match(approval, /missing.*?surface.*?(?:pause|stop).*?(?:never|do not).*?(?:invent|guess)/i);
+});
+
+test("design revisions preserve the prior pair until replacement approval", () => {
+  const revision = markdownSection(designArtifactFile(), "Revise an approved design").replace(/\s+/g, " ");
+  assert.match(revision, /next.*?number.*?pair.*?draft/i);
+  assert.match(revision, /supersedes.*?(?:previous|prior|old).*?NNN/i);
+  assert.match(revision, /(?:never|do not).*?(?:modify|edit|overwrite).*?approved.*?\.pen/i);
+  assert.match(revision, /prior.*?remains approved.*?until.*?(?:replacement|revision|new).*?(?:approved|approval)/i);
+  assert.match(revision, /(?:only after|once).*?explicit human approval.*?superseded/i);
+  assert.match(revision, /(?:declined|unapproved).*?(?:prior|old).*?unchanged/i);
+  assert.match(revision, /(?:copy|duplicate).*?(?:before|then).*?(?:edit|author)/i);
+});
+
+test("Pencil outages and wrong documents pause only visual work", () => {
+  const capability = markdownSection(designArtifactFile(), "Pencil capability").replace(/\s+/g, " ");
+  assert.match(capability, /get_app_state.*?execute/);
+  assert.match(capability, /(?:unavailable|absent|missing).*?(?:wrong|incorrect).*?(?:file|document).*?pause only.*?authoring.*?review.*?approval/i);
+  assert.match(capability, /resolution.*?nonvisual.*?continue/i);
+  assert.match(capability, /(?:do not|never).*?(?:fabricate|claim|invent).*?(?:capture|screenshot|verification)/i);
+  assert.match(capability, /get_app_state.*?(?:before|prior to).*?(?:mutation|edit)/i);
+  assert.match(capability, /https:\/\/docs\.pencil\.dev\/getting-started\/ai-integration/);
+  assert.match(capability, /https:\/\/docs\.pencil\.dev\/core-concepts\/pen-files/);
+});
+
+test("design-artifacts consumes product context read-only and routes durable contradictions", () => {
+  const context = markdownSection(designArtifactFile(), "Product context").replace(/\s+/g, " ");
+  assert.match(context, /docs\/product\.md.*?exists.*?read.*?read-only/i);
+  assert.match(context, /(?:absent|missing).*?continue.*?(?:never|do not).*?create/i);
+  assert.match(context, /(?:never|do not).*?(?:create|edit|write).*?docs\/product\.md/i);
+  assert.match(context, /durable contradiction.*?pause.*?(?:\$|plus-ultra:)product-discovery.*?focused.*?explicit human approval.*?resume/i);
+});
+
+test("DESIGN.md defines reusable design rules without duplicating concrete screens", () => {
+  const skill = designArtifactFile();
+  const template = designArtifactFile("assets/DESIGN.md");
+  const designSystem = markdownSection(skill, "Maintain DESIGN.md").replace(/\s+/g, " ");
+  const headings = [...template.matchAll(/^## (.+)$/gm)].map((match) => match[1]);
+  assert.deepEqual(headings, [
+    "Principles", "Tokens", "Typography", "Color", "Spacing and density",
+    "Components and states", "Responsive behavior", "Motion", "Accessibility",
+  ]);
+  assert.deepEqual([...template.matchAll(/^### (.+)$/gm)].map((match) => match[1]), [
+    "Primitive tokens", "Semantic tokens", "Component tokens",
+  ]);
+  assert.match(designSystem, /(?:root|root-level).*?DESIGN\.md|DESIGN\.md.*?(?:root|root-level)/i);
+  assert.match(designSystem, /assets\/DESIGN\.md/);
+  assert.match(designSystem, /reusable.*?(?:rules|principles|tokens)/i);
+  assert.match(designSystem, /(?:do not|never).*?duplicat.*?(?:screen|layout).*?\.pen/i);
+  assert.match(designSystem, /(?:show|present).*?proposal.*?explicit human approval.*?(?:write|update|creat)/i);
+  assert.match(designSystem, /(?:declined|unapproved).*?unchanged/i);
+  assert.match(designSystem, /preserv.*?unaffected/i);
+  assert.match(designSystem, /(?:does not|never).*?(?:approve|approval).*?(?:artifact|\.pen)/i);
+});
+
+test("design review is read-only and reports evidence without silently approving or repairing", () => {
+  const review = markdownSection(designArtifactFile(), "Review a design").replace(/\s+/g, " ");
+  assert.match(review, /read-only/i);
+  assert.match(review, /(?:manifest|Issue).*?(?:surface|IDs).*?DESIGN\.md/);
+  assert.match(review, /(?:finding|mismatch).*?(?:path|ID).*?evidence.*?(?:required|proposed).*?change/i);
+  assert.match(review, /(?:do not|never).*?(?:edit|mutat).*?(?:approve|status)/i);
+  assert.match(review, /(?:missing|unavailable).*?(?:evidence|Pencil).*?(?:incomplete|unverified)/i);
+});
+
+test("design resolution worked cases cover story, journey, exclusions, none, and ambiguity", () => {
+  const scenarios = markdownSection(designArtifactFile(), "Resolution examples");
+  const rows = scenarios.split("\n").filter((line) => line.startsWith("| "));
+  const row = (label) => {
+    const match = rows.find((line) => line.startsWith(`| ${label} |`));
+    assert.ok(match, `${label} example exists`);
+    return match;
+  };
+  assert.match(row("Single story"), /184.*?approved.*?\[184\].*?selected/);
+  assert.match(row("Shared journey"), /185.*?approved.*?\[180, 184, 185\].*?selected/);
+  assert.match(row("Excluded statuses"), /184.*?draft.*?superseded.*?none/);
+  assert.match(row("No match"), /186.*?approved.*?\[180, 184, 185\].*?none/);
+  assert.match(row("Ambiguous"), /184.*?approved.*?approved.*?ambiguous.*?explicit selection/);
+});
+
+test("approved spec 011 and README document the bounded design-artifact workflow", () => {
+  const specPath = "specs/011-define-pencil-backed-design-artifacts.md";
+  assert.ok(existsSync(join(repoRoot, specPath)), `${specPath} exists`);
+  const spec = readRelative(specPath);
+  const frontmatter = parseFrontmatter(spec);
+  assert.equal(frontmatter.title, "Define Pencil-backed design artifacts");
+  assert.equal(frontmatter.status, "approved");
+  assert.equal(frontmatter.issue, "16");
+  assert.match(frontmatter.created, /^\d{4}-\d{2}-\d{2}$/);
+  for (const heading of ["Problem", "Goals / Non-goals", "Acceptance criteria", "Interface contracts", "Architecture boundaries", "Functional core", "Data model", "Test plan", "Risks"]) {
+    markdownSection(spec, heading);
+  }
+  for (const issue of ["#35", "#24", "#22"]) assert.ok(spec.includes(issue), `${issue} retains its boundary`);
+  assert.match(spec, /DesignArtifactManifest/);
+  assert.match(spec, /DesignResolution/);
+  const readme = markdownSection(readRelative("README.md"), "Design artifacts").replace(/\s+/g, " ");
+  assert.match(readme, /plus-ultra:design-artifacts/);
+  assert.match(readme, /designs\/NNN-slug\.md.*?designs\/NNN-slug\.pen/);
+  assert.match(readme, /draft.*?approved.*?superseded/);
+  assert.match(readme, /issues.*?epic.*?stor(?:y|ies)/i);
+  assert.match(readme, /exact.*?approved.*?none.*?ambiguous.*?explicit.*?selection/i);
+  assert.match(readme, /explicit human approval/);
+  assert.match(readme, /DESIGN\.md.*?reusable/i);
+  assert.match(readme, /Pencil.*?optional.*?nonvisual.*?continue/i);
+});
+
 test("workflow-risk is a portable, issue-linked FAST/STANDARD/CRITICAL contract", () => {
   const skillPath = "skills/workflow-risk/SKILL.md";
   assert.ok(existsSync(join(repoRoot, skillPath)), `${skillPath} exists`);


### PR DESCRIPTION
## At a glance

Adds `plus-ultra:design-artifacts`, giving contributors a durable, approval-gated way to connect Pencil design pairs and reusable system rules to GitHub Issues.

## Diagram

```mermaid
stateDiagram-v2
  [*] --> draft
  draft --> approved: explicit human approval
  approved --> superseded: approved replacement
  superseded --> [*]
```

## Traceability

- Issue: #16
- Spec: `specs/011-define-pencil-backed-design-artifacts.md` (approved)
- Refs #16

## Summary

- Adds deterministic approved-artifact resolution, explicit Issue coverage, read-only review, and immutable approved Pencil revisions
- Adds canonical reusable `DESIGN.md` and manifest templates while keeping Pencil optional and external

## Testing

- `node --test tests/*.test.mjs` — 141 passing
- `node scripts/validate-packaging.mjs`, Claude plugin validation, clean Codex install, and byte-level asset comparisons

## Risks

- Live Pencil MCP visual verification was not available; the skill explicitly pauses visual work rather than fabricating evidence

## Review Guidance

- Review lifecycle transitions and exact-match ambiguity behavior in `skills/design-artifacts/SKILL.md`, then the corresponding contract tests
